### PR TITLE
feat(process-variables-helper): retrieve full moddle elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ const scopeVariables = getVariablesForScope('Process_1', rootElement.businessObj
 */
 ```
 
+Note that `origin` and `scope` retrieves the full moddle element. The example outputs are reduced due to better readibility.
+
 Note that [camunda-bpmn-moddle](https://github.com/camunda/camunda-bpmn-moddle) descriptors have to be installed.
 
 ## See also

--- a/src/ProcessVariablesHelper.js
+++ b/src/ProcessVariablesHelper.js
@@ -10,8 +10,8 @@ import {
 /**
  * @typedef {Object} ProcessVariable
  * @property {string} name
- * @property {Array<string>} origin
- * @property {string} scope
+ * @property {Array<ModdleElement>} origin
+ * @property {ModdleElement} scope
  */
 
 /**
@@ -20,7 +20,7 @@ import {
  *
  * @param {ModdleElement} flowElement
  * @param {ModdleElement} outputParameter
- * @param {String} defaultScope
+ * @param {ModdleElement} defaultScope
  *
  * @returns {ProcessVariable}
  */
@@ -29,7 +29,7 @@ function createProcessVariable(flowElement, outputParameter, defaultScope) {
 
   return {
     name: outputParameter.name,
-    origin: [flowElement.id],
+    origin: [flowElement],
     scope: scope,
   };
 }
@@ -59,7 +59,7 @@ export function getProcessVariables(containerElement) {
       var newVariable = createProcessVariable(
         element,
         parameter,
-        containerElement.id
+        containerElement
       );
 
       addVariableToList(processVariables, newVariable);
@@ -89,7 +89,7 @@ export function getVariablesForScope(scope, rootElement) {
 
   // (1) get variables for given scope
   var scopeVariables = filter(allVariables, function(variable) {
-    return variable.scope === scopeElement.id;
+    return variable.scope.id === scopeElement.id;
   });
 
   // (2) get variables for parent scopes
@@ -97,7 +97,7 @@ export function getVariablesForScope(scope, rootElement) {
 
   var parentsScopeVariables = filter(allVariables, function(variable) {
     return find(parents, function(parent) {
-      return parent.id === variable.scope;
+      return parent.id === variable.scope.id;
     });
   });
 
@@ -119,7 +119,7 @@ function getScope(element, globalScope, variableName) {
     );
   });
 
-  return scopedParent ? scopedParent.id : globalScope;
+  return scopedParent ? scopedParent : globalScope;
 }
 
 function combineArrays(a, b) {

--- a/test/spec/ProcessVariablesHelperSpec.js
+++ b/test/spec/ProcessVariablesHelperSpec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { sortBy } from 'min-dash';
+import { sortBy, map } from 'min-dash';
 
 import BpmnModdle from 'bpmn-moddle';
 
@@ -30,7 +30,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const variables = getProcessVariables(rootElement);
 
       // then
-      expect(variables).to.eql([
+      expect(convertToTestable(variables)).to.eql([
         { name: 'variable1', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
       ]);
@@ -50,7 +50,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const variables = getProcessVariables(rootElement);
 
       // then
-      expect(variables).to.eql([
+      expect(convertToTestable(variables)).to.eql([
         { name: 'variable1', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable3', origin: ['Task_2'], scope: 'Process_1' },
@@ -71,7 +71,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const variables = getProcessVariables(rootElement);
 
       // then
-      expect(variables).to.eql([
+      expect(convertToTestable(variables)).to.eql([
         { name: 'variable1', origin: ['Task_1', 'Task_2'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable3', origin: ['Task_2'], scope: 'Process_1' },
@@ -92,7 +92,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const variables = getProcessVariables(rootElement);
 
       // then
-      expect(variables).to.eql([
+      expect(convertToTestable(variables)).to.eql([
         { name: 'variable1', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable3', origin: ['Task_2'], scope: 'SubProcess_1' },
@@ -113,7 +113,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const variables = getProcessVariables(rootElement);
 
       // then
-      expect(variables).to.eql([
+      expect(convertToTestable(variables)).to.eql([
         { name: 'variable1', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_2'], scope: 'SubProcess_1' },
@@ -135,7 +135,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const variables = getProcessVariables(rootElement);
 
       // then
-      expect(variables).to.eql([
+      expect(convertToTestable(variables)).to.eql([
         { name: 'variable1', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable3', origin: ['SubProcess_1'], scope: 'Process_1' },
@@ -157,7 +157,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const variables = getProcessVariables(rootElement);
 
       // then
-      expect(variables).to.eql([
+      expect(convertToTestable(variables)).to.eql([
         { name: 'variable1', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable3', origin: ['Task_2'], scope: 'SubProcess_1' },
@@ -180,7 +180,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const sortedVariables = sortVariablesByName(variables);
 
       // then
-      expect(sortedVariables).to.eql([
+      expect(convertToTestable(sortedVariables)).to.eql([
         { name: 'variable01', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable02', origin: ['Event_2'], scope: 'Process_1' },
         { name: 'variable03', origin: ['SubProcess_1'], scope: 'Process_1' },
@@ -218,7 +218,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       const variables = getVariablesForScope('Process_1', rootElement);
 
       // then
-      expect(variables).to.eql([
+      expect(convertToTestable(variables)).to.eql([
         { name: 'variable1', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
       ]);
@@ -242,7 +242,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       // then
 
       // own + all variables from parent scope
-      expect(sortedVariables).to.eql([
+      expect(convertToTestable(sortedVariables)).to.eql([
         { name: 'variable1', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable2', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable3', origin: ['Task_2'], scope: 'SubProcess_1' }
@@ -267,7 +267,7 @@ describe('providers/camunda/util - getProcessVariables', function() {
       // then
 
       // own + all variables from parent scope
-      expect(sortedVariables).to.eql([
+      expect(convertToTestable(sortedVariables)).to.eql([
         { name: 'variable01', origin: ['Task_1'], scope: 'Process_1' },
         { name: 'variable02', origin: ['Event_2'], scope: 'Process_1' },
         { name: 'variable03', origin: ['SubProcess_1'], scope: 'Process_1' },
@@ -313,5 +313,18 @@ function read(path, encoding = 'utf8') {
 function sortVariablesByName(variables) {
   return sortBy(variables, function(variable) {
     return variable.name;
+  });
+}
+
+// converts the variables list from full moddle elements to only id, for better testability
+function convertToTestable(variables) {
+  return map(variables, function(variable) {
+    return {
+      name: variable.name,
+      origin: map(variable.origin, function(origin) {
+        return origin.id;
+      }),
+      scope: variable.scope.id
+    };
   });
 }


### PR DESCRIPTION
Let's return the full moddle elements instead of only the id. 
Reason: let's give the user of the API the choice of what to do next with the variables list. In some cases (e.g. inside the Properties Panel Variables Overview) the id from the origin and the scope might not be enough.


__Which issue does this PR address?__

Closes no issue.

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/.github/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
