### PR TITLE
Quirks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: '14.x'
     - name: Cache Node.js modules

--- a/src/util/EventDefinitionsUtil.js
+++ b/src/util/EventDefinitionsUtil.js
@@ -3,9 +3,9 @@ import { filter } from 'min-dash';
 /**
  *
  * @param {ModdleElement} element
- * @param {String} [type] - optional
+ * @param {string} [type] - optional
  *
- * @return {Array<ModdleElement>|null} collection of event definitions
+ * @return {Array<ModdleElement>|undefined} collection of event definitions or none
  */
 export function getEventDefinitions(element, type) {
   var eventDefinitions = element.get('eventDefinitions');


### PR DESCRIPTION
Missing bits from #10.

One Note on the `actions/setup-node` version. I updated it for this time. I discussed with @nikku that it would make sense to have a central workflow configuration for recurrent CI setups, e.g. we have here for this project. Therefore we would not need to update the used actions every time in any repo but can configure it in a basic manner.

https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization