### PR TITLE
fix(zeebe): don't blow up on empty multiInstanceLoopCharacteristics

### DIFF
--- a/src/zeebe/util/ExtensionElementsUtil.js
+++ b/src/zeebe/util/ExtensionElementsUtil.js
@@ -66,7 +66,8 @@ export function getInMappings(element) {
  * @returns {String} outputCollection
  */
 export function getInputElement(loopCharacteristics) {
-  return getElements(loopCharacteristics, 'zeebe:LoopCharacteristics')[0].inputElement;
+  const extensionElement = getElements(loopCharacteristics, 'zeebe:LoopCharacteristics')[0];
+  return extensionElement && extensionElement.inputElement;
 }
 
 /**
@@ -76,7 +77,9 @@ export function getInputElement(loopCharacteristics) {
  * @returns {String} outputCollection
  */
 export function getOutputCollection(loopCharacteristics) {
-  return getElements(loopCharacteristics, 'zeebe:LoopCharacteristics')[0].outputCollection;
+  const extensionElement = getElements(loopCharacteristics, 'zeebe:LoopCharacteristics')[0];
+  return extensionElement && extensionElement.outputCollection;
+
 }
 
 /**

--- a/test/zeebe/fixtures/mi-subprocess-empty.bpmn
+++ b/test/zeebe/fixtures/mi-subprocess-empty.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:subProcess id="Subprocess_1">
+      <bpmn:extensionElements />
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements></bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:task id="Task_1" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1q2g7ap_di" bpmnElement="Subprocess_1" isExpanded="true">
+        <dc:Bounds x="160" y="80" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sh98fu_di" bpmnElement="Task_1">
+        <dc:Bounds x="280" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/zeebe/spec/extractors/extractInputElementSpec.js
+++ b/test/zeebe/spec/extractors/extractInputElementSpec.js
@@ -39,6 +39,29 @@ describe('zeebe/extractors - input element', function() {
     ]);
   });
 
+
+  it('should not extract variables from empty loopCharacteristics', async function() {
+
+    // given
+    const xml = read('test/zeebe/fixtures/mi-subprocess-empty.bpmn');
+
+    const definitions = await parse(xml);
+
+    const rootElement = getRootElement(definitions);
+
+    const elements = selfAndAllFlowElements([rootElement], false);
+
+    // when
+    const variables = extractVariables({
+      elements,
+      containerElement: rootElement,
+      processVariables: []
+    });
+
+    // then
+    expect(convertToTestable(variables)).to.eql([]);
+  });
+
 });
 
 

--- a/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
@@ -39,6 +39,29 @@ describe('zeebe/extractors - output collections', function() {
     ]);
   });
 
+
+  it('should not extract variables from empty loopCharacteristics', async function() {
+
+    // given
+    const xml = read('test/zeebe/fixtures/mi-subprocess-empty.bpmn');
+
+    const definitions = await parse(xml);
+
+    const rootElement = getRootElement(definitions);
+
+    const elements = selfAndAllFlowElements([rootElement], false);
+
+    // when
+    const variables = extractVariables({
+      elements,
+      containerElement: rootElement,
+      processVariables: []
+    });
+
+    // then
+    expect(convertToTestable(variables)).to.eql([]);
+  });
+
 });
 
 


### PR DESCRIPTION
During creation of a multi instance Activity, the required extension elements are not present yet:
```
<bpmn:multiInstanceLoopCharacteristics>
  <bpmn:extensionElements></bpmn:extensionElements>
</bpmn:multiInstanceLoopCharacteristics>
```

This leads to the error `TypeError: Cannot read properties of undefined (reading 'inputElement')` during modeling. This PR ensures that we recover from it.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
