### PR TITLE
Fix zeebe distro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+zeebe
 .nyc_output
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@bpmn-io/extract-process-variables](https://github.com/b
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.5.1
+
+_Republish of 0.5.0 with backwards compatible folder structure_
+
 ## 0.5.0
 
 * `FEAT`: add support for Camunda Platform 8 diagrams ([#20](https://github.com/bpmn-io/extract-process-variables/pull/20))

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.esm.js",
   "exports": {
     ".": "./dist/index.js",
-    "./zeebe": "./dist/zeebe/index.js"
+    "./zeebe": "./zeebe/index.js"
   },
   "source": "src/index.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,9 +2,6 @@ import json from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-import pkg from './package.json';
-
-
 function pgl(plugins=[]) {
   return [
     json(),
@@ -14,20 +11,29 @@ function pgl(plugins=[]) {
   ];
 }
 
-const exports = pkg.exports;
-
-const config = Object.keys(exports).map(key => {
-  return {
-    input: `src/${key}/index.js`,
+const config = [
+  {
+    input: 'src/index.js',
     output: [
-      { file: `dist/${key}/index.js`, format: 'cjs' },
-      { file: `dist/${key}/index.esm.js`, format: 'es' }
+      { file: 'dist/index.js', format: 'cjs' },
+      { file: 'dist/index.esm.js', format: 'es' }
     ],
     external: [
       'min-dash'
     ],
     plugins: pgl()
-  };
-});
+  },
+  {
+    input: 'src/index.js',
+    output: [
+      { file: 'zeebe/index.js', format: 'cjs' },
+      { file: 'zeebe/index.esm.js', format: 'es' }
+    ],
+    external: [
+      'min-dash'
+    ],
+    plugins: pgl()
+  }
+];
 
 export default config;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ const config = [
     plugins: pgl()
   },
   {
-    input: 'src/index.js',
+    input: 'src/zeebe/index.js',
     output: [
       { file: 'zeebe/index.js', format: 'cjs' },
       { file: 'zeebe/index.esm.js', format: 'es' }

--- a/test/distro/extract-process-variables.js
+++ b/test/distro/extract-process-variables.js
@@ -13,7 +13,7 @@ describe('exctract-process-variables', function() {
 
 
   it('should expose zeebe CJS bundle', function() {
-    const extractProcessVariables = require('../../dist/zeebe');
+    const extractProcessVariables = require('../../zeebe');
 
     expect(extractProcessVariables.getProcessVariables).to.exist;
   });


### PR DESCRIPTION
I found a Problem when integrating the properties panel into the modeler: https://github.com/camunda/camunda-modeler/runs/7633942478?check_suite_focus=true#step:6:309

It seems that package.exports is not supported by webpack and it is using the project folder structure instead of the defined exports (see discussion why we added https://github.com/bpmn-io/extract-process-variables/pull/20#discussion_r923832953)

According to the docs, this should be supported by webpack@5, so we might want to upgrade in the future. For this Release, I created a PR that creates a compatible folder structure during release.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
