### PR TITLE
fix: script task result variable scope redefines if output mapping exists

### DIFF
--- a/src/zeebe/extractors/extractResultVariables.js
+++ b/src/zeebe/extractors/extractResultVariables.js
@@ -41,6 +41,12 @@ export default function(options) {
 
       // result variable will have local scope
       containerElement = element;
+
+      // check if the output have same name as resultVariable, only proceed with output variable
+      if (processVariables.some(variable => variable.name === resultVariable)) {
+        return processVariables;
+      }
+
     }
 
     if (resultVariable) {

--- a/src/zeebe/extractors/extractResultVariables.js
+++ b/src/zeebe/extractors/extractResultVariables.js
@@ -36,6 +36,13 @@ export default function(options) {
 
     var resultVariable = baseElement.resultVariable;
 
+    // Checks if output variable exists, the scope gets redefined
+    if (processVariables.some(x => x.origin[0] === element && x.scope === containerElement)) {
+
+      // result variable will have local scope
+      containerElement = element;
+    }
+
     if (resultVariable) {
       var newVariable = createProcessVariable(
         element,

--- a/test/zeebe/fixtures/script-task-output.bpmn
+++ b/test/zeebe/fixtures/script-task-output.bpmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14rdixd" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:scriptTask id="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:script expression="={}" resultVariable="foo" />
+        <zeebe:ioMapping>
+          <zeebe:output target="output" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_074uvug_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>
+

--- a/test/zeebe/fixtures/script-task-same-output-and-result-variable.bpmn
+++ b/test/zeebe/fixtures/script-task-same-output-and-result-variable.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:scriptTask id="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=123" resultVariable="foo" />
+        <zeebe:ioMapping>
+          <zeebe:output source="={}" target="foo" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0258i89_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -230,6 +230,25 @@ describe('zeebe/process variables module', function() {
       ]);
     });
 
+
+    it('should extract only output variable if same name result variable exists - simple process with script', async function() {
+
+      // given
+      const xml = read('test/zeebe/fixtures/script-task-same-output-and-result-variable.bpmn');
+
+      const definitions = await parse(xml);
+
+      const rootElement = getRootElement(definitions);
+
+      // when
+      const variables = await getProcessVariables(rootElement);
+
+      // then
+      expect(convertToTestable(variables)).to.eql([
+        { name: 'foo', origin: [ 'Task_1' ], scope: 'Process_1' }
+      ]);
+    });
+
   });
 
 

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -210,6 +210,26 @@ describe('zeebe/process variables module', function() {
 
     });
 
+
+    it('should extract variables with re define resultVariable scope if output mapping exists - script task', async function() {
+
+      // given
+      const xml = read('test/zeebe/fixtures/script-task-output.bpmn');
+
+      const definitions = await parse(xml);
+
+      const rootElement = getRootElement(definitions);
+
+      // when
+      const variables = await getProcessVariables(rootElement);
+
+      // then
+      expect(convertToTestable(variables)).to.eql([
+        { name: 'output', origin: [ 'Task_1' ], scope: 'Process_1' },
+        { name: 'foo', origin: [ 'Task_1' ], scope: 'Task_1' },
+      ]);
+    });
+
   });
 
 


### PR DESCRIPTION
Related to: camunda-modeler [#4737](https://github.com/camunda/camunda-modeler/issues/4737)

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 
### Script Task
- If output mapping exists, result variable scope should be local. 
![Dec-16-2024 23-10-38](https://github.com/user-attachments/assets/85d0d021-5c86-4221-b430-9a01995cf299)

- If output mapping doesn't exist, result variable scope is global. 
![Dec-16-2024 23-09-56](https://github.com/user-attachments/assets/78da554d-722c-4a72-bd5b-d0e75ab732e2)

You can test the implementation by running this command: `npx @bpmn-io/sr  bpmn-io/variable-resolver#variable-scoping -l bpmn-io/extract-process-variables#script-variable-scope`
### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
