### PR TITLE
Local scope fixes + prepare `v2.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to [@bpmn-io/extract-process-variables](https://github.com/b
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.2.0
+
+* `FEAT`: recognize output mapping variables with paths ([#35](https://github.com/bpmn-io/extract-process-variables/pull/35))
+* `FIX`: correctly recognize local `resultVariable` ([#35](https://github.com/bpmn-io/extract-process-variables/pull/35))
+* `FIX`: ensure input mapping always creates local scope ([#35](https://github.com/bpmn-io/extract-process-variables/pull/35))
+
 ## 2.1.1
 
 * `FIX`: do not expose unnamed variables ([#37](https://github.com/bpmn-io/extract-process-variables/pull/37))

--- a/src/zeebe/extractors/extractInputMappings.js
+++ b/src/zeebe/extractors/extractInputMappings.js
@@ -42,7 +42,8 @@ export default function extractInputMappings(options) {
       var newVariable = createProcessVariable(
         element,
         mapping.target,
-        element
+        element,
+        true
       );
 
       addVariableToList(processVariables, newVariable);

--- a/src/zeebe/extractors/extractResultVariables.js
+++ b/src/zeebe/extractors/extractResultVariables.js
@@ -59,17 +59,14 @@ export default function extractResultVariables(options) {
 
     if (hasOutMappings(element)) {
       containerElement = element;
-
-      if (processVariables.some(variable => variable.name === resultVariable)) {
-        return processVariables;
-      }
     }
 
     if (resultVariable) {
       var newVariable = createProcessVariable(
         element,
         resultVariable,
-        containerElement
+        containerElement,
+        true
       );
 
       addVariableToList(processVariables, newVariable);

--- a/src/zeebe/util/ExtensionElementsUtil.js
+++ b/src/zeebe/util/ExtensionElementsUtil.js
@@ -13,31 +13,6 @@ export function getInputOutput(element) {
 }
 
 /**
- * Return all input parameters existing in the business object, and
- * an empty array if none exist.
- *
- * @param  {ModdleElement} element
- *
- * @return {Array<ModdleElement>} a list of input parameter objects
- */
-export function getInputParameters(element) {
-  return getParameters(element, 'inputParameters');
-}
-
-/**
- * Return all output parameters existing in the business object, and
- * an empty array if none exist.
- *
- * @param  {ModdleElement} element
- * @param  {boolean} insideConnector
- *
- * @return {Array<ModdleElement>} a list of output parameter objects
- */
-export function getOutputParameters(element) {
-  return getParameters(element, 'output');
-}
-
-/**
  * Return output mappings existing in the business object
  *
  * @param {ModdleElement} element
@@ -129,12 +104,6 @@ function getElements(element, type, property) {
   var elements = getExtensionElements(element, type);
 
   return !property ? elements : (elements[0] || {})[property] || [];
-}
-
-function getParameters(element, property) {
-  var inputOutput = getInputOutput(element);
-
-  return (inputOutput && inputOutput.get(property)) || [];
 }
 
 function getExtensionElements(element, type) {

--- a/src/zeebe/util/ProcessVariablesUtil.js
+++ b/src/zeebe/util/ProcessVariablesUtil.js
@@ -66,7 +66,30 @@ function getScope(element, globalScope, variableName, includeSelf) {
 
 function hasInputMapping(element, name) {
   return find(getInputMappings(element), function(input) {
-    return input.target === name;
+
+    // inputs define mappings by name, an input
+    // <foo.baz> defines a local variable <foo> with the value <baz>
+    // we match if that variable part is either equal or a prefix of name
+
+    const localName = input.target;
+
+    if (!localName) {
+      return false;
+    }
+
+    const localPart = localName.split('.')[0];
+
+    // exact match
+    if (localName === name) {
+      return true;
+    }
+
+    // name is hierarchical <foo.bar>, localPart is prefix <foo>
+    if (name.startsWith(localPart + '.')) {
+      return true;
+    }
+
+    return false;
   });
 }
 

--- a/src/zeebe/util/ProcessVariablesUtil.js
+++ b/src/zeebe/util/ProcessVariablesUtil.js
@@ -1,6 +1,6 @@
 import { find, findIndex } from 'min-dash';
 
-import { getInputParameters } from './ExtensionElementsUtil.js';
+import { getInputMappings } from './ExtensionElementsUtil.js';
 
 import { getParents } from '../../shared/util/ElementsUtil.js';
 
@@ -57,15 +57,15 @@ function getScope(element, globalScope, variableName, includeSelf) {
 
   var scopedParent = find(parents, function(parent) {
     return (
-      hasInputParameter(parent, variableName)
+      hasInputMapping(parent, variableName)
     );
   });
 
   return scopedParent ? scopedParent : globalScope;
 }
 
-function hasInputParameter(element, name) {
-  return find(getInputParameters(element), function(input) {
+function hasInputMapping(element, name) {
+  return find(getInputMappings(element), function(input) {
     return input.target === name;
   });
 }

--- a/src/zeebe/util/ProcessVariablesUtil.js
+++ b/src/zeebe/util/ProcessVariablesUtil.js
@@ -57,19 +57,11 @@ function getScope(element, globalScope, variableName, includeSelf) {
 
   var scopedParent = find(parents, function(parent) {
     return (
-      is(parent, 'bpmn:SubProcess') && hasInputParameter(parent, variableName)
+      hasInputParameter(parent, variableName)
     );
   });
 
   return scopedParent ? scopedParent : globalScope;
-}
-
-function is(element, type) {
-  return (
-    element &&
-      typeof element.$instanceOf === 'function' &&
-      element.$instanceOf(type)
-  );
 }
 
 function hasInputParameter(element, name) {

--- a/test/zeebe/TestHelper.js
+++ b/test/zeebe/TestHelper.js
@@ -1,0 +1,42 @@
+import { map } from 'min-dash';
+
+import { BpmnModdle } from 'bpmn-moddle';
+
+import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json' with { type: 'json' };
+
+import fs from 'node:fs';
+
+
+export function getRootElement(model) {
+  return model.rootElement.get('rootElements')[0];
+}
+
+export async function parseXML(xml) {
+  const moddle = new BpmnModdle({
+    zeebe: ZeebeModdle,
+  });
+
+  return moddle.fromXML(xml);
+}
+
+export function readFile(path, encoding = 'utf8') {
+  return fs.readFileSync(path, encoding);
+}
+
+export async function readModel(path) {
+  const xml = readFile(path);
+
+  return parseXML(xml);
+}
+
+export function convertToTestable(variables) {
+  return map(variables, function(variable) {
+    return {
+      name: variable.name,
+      origin: map(variable.origin, function(origin) {
+        return origin.id;
+      }),
+      scope: variable.scope.id
+    };
+  });
+}

--- a/test/zeebe/fixtures/ad-hoc-sub-process.bpmn
+++ b/test/zeebe/fixtures/ad-hoc-sub-process.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0-rc.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:adHocSubProcess id="SubProcess_1" name="SubProcess_1">
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="AdHocSubProcess_1">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
         <zeebe:adHoc outputCollection="variables" outputElement="=variable" />
@@ -18,7 +18,7 @@
       <bpmn:text>outputElement: variable
 outputCollection: variables</bpmn:text>
     </bpmn:textAnnotation>
-    <bpmn:association id="Association_0kjh134" associationDirection="None" sourceRef="SubProcess_1" targetRef="TextAnnotation_03j09jg" />
+    <bpmn:association id="Association_0kjh134" associationDirection="None" sourceRef="AdHocSubProcess_1" targetRef="TextAnnotation_03j09jg" />
     <bpmn:textAnnotation id="TextAnnotation_0umy5l8">
       <bpmn:text>out: variable</bpmn:text>
     </bpmn:textAnnotation>
@@ -26,7 +26,7 @@ outputCollection: variables</bpmn:text>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="SubProcess_1" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
         <dc:Bounds x="160" y="190" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_11csst4_di" bpmnElement="Task_1">

--- a/test/zeebe/fixtures/ad-hoc-sub-process.nested-partial-writes.bpmn
+++ b/test/zeebe/fixtures/ad-hoc-sub-process.nested-partial-writes.bpmn
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0-dev" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1" name="out: toolResult.email = &#34;my@mail&#34;" isExecutable="true">
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="AdHocSubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition />
+        <zeebe:adHoc outputCollection="toolResults" outputElement="=toolResult" />
+        <zeebe:ioMapping>
+          <zeebe:input target="toolResult" />
+          <zeebe:input target="toolResults" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:scriptTask id="ScriptTask_1" name="ScriptTask_1">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=&#34;YES&#34;" resultVariable="toolResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:scriptTask id="ScriptTask_2" name="ScriptTask_2">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=&#34;my@mail&#34;" resultVariable="userEmail" />
+          <zeebe:ioMapping>
+            <zeebe:output target="toolResult.email" source="= userEmail" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:textAnnotation id="TextAnnotation_03j09jg">
+      <bpmn:text>outputElement: toolResult
+outputCollection: toolResults</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0kjh134" associationDirection="None" sourceRef="AdHocSubProcess_1" targetRef="TextAnnotation_03j09jg" />
+    <bpmn:textAnnotation id="TextAnnotation_1850vkp">
+      <bpmn:text>out: toolCall = "YES"</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="TextAnnotation_1h6zojv">
+      <bpmn:text>out: toolResult.email = "my@mail"</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0hzodcg" associationDirection="None" sourceRef="ScriptTask_1" targetRef="TextAnnotation_1850vkp" />
+    <bpmn:association id="Association_1cggoob" associationDirection="None" sourceRef="ScriptTask_2" targetRef="TextAnnotation_1h6zojv" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
+        <dc:Bounds x="160" y="190" width="300" height="310" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16tkphp_di" bpmnElement="ScriptTask_1">
+        <dc:Bounds x="300" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1w3kwa9" bpmnElement="ScriptTask_2">
+        <dc:Bounds x="300" y="380" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0hzodcg_di" bpmnElement="Association_0hzodcg">
+        <di:waypoint x="400" y="264" />
+        <di:waypoint x="549" y="186" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1cggoob_di" bpmnElement="Association_1cggoob">
+        <di:waypoint x="400" y="396" />
+        <di:waypoint x="520" y="339" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_03j09jg_di" bpmnElement="TextAnnotation_03j09jg">
+        <dc:Bounds x="380" y="80" width="220" height="41" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0kjh134_di" bpmnElement="Association_0kjh134">
+        <di:waypoint x="354" y="190" />
+        <di:waypoint x="409" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_1850vkp_di" bpmnElement="TextAnnotation_1850vkp">
+        <dc:Bounds x="520" y="160" width="130" height="25.999998092651367" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ik99qc" bpmnElement="TextAnnotation_1h6zojv">
+        <dc:Bounds x="520" y="310" width="200" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/zeebe/fixtures/ad-hoc-sub-process.no-output-collection.bpmn
+++ b/test/zeebe/fixtures/ad-hoc-sub-process.no-output-collection.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0-rc.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:adHocSubProcess id="SubProcess_1" name="SubProcess_1">
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="AdHocSubProcess_1">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
         <zeebe:adHoc />
@@ -18,11 +18,11 @@
       <bpmn:text>outputElement: &lt;empty&gt;
 outputCollection: &lt;empty&gt;</bpmn:text>
     </bpmn:textAnnotation>
-    <bpmn:association id="Association_0kjh134" associationDirection="None" sourceRef="SubProcess_1" targetRef="TextAnnotation_03j09jg" />
+    <bpmn:association id="Association_0kjh134" associationDirection="None" sourceRef="AdHocSubProcess_1" targetRef="TextAnnotation_03j09jg" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="SubProcess_1" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
         <dc:Bounds x="160" y="150" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_11csst4_di" bpmnElement="Task_1">

--- a/test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn
+++ b/test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn
@@ -1,51 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0-rc.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0-dev" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="AdHocSubProcess_1">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
-        <zeebe:adHoc outputCollection="variables" outputElement="=variable" />
+        <zeebe:adHoc outputCollection="toolResults" outputElement="=toolResult" />
         <zeebe:ioMapping>
-          <zeebe:input target="variables" />
-          <zeebe:input target="variable" />
+          <zeebe:input target="toolResult" />
+          <zeebe:input target="toolResults" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
-      <bpmn:serviceTask id="Task_1" name="Task_1">
+      <bpmn:serviceTask id="Task_1" name="Task_1&#10;&#10;Produce &#39;1&#39;">
         <bpmn:extensionElements>
           <zeebe:ioMapping>
-            <zeebe:output source="=1" target="variable" />
+            <zeebe:output source="=1" target="toolResult" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
       </bpmn:serviceTask>
+      <bpmn:scriptTask id="ScriptTask_1" name="ScriptTask_1&#10;&#10;Produce &#39;&#34;YES&#34;&#39;">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=&#34;YES&#34;" resultVariable="toolResult" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:subProcess id="EventSubProcess_1" name="EventSubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="MessageStartEvent_1">
+          <bpmn:outgoing>Flow_1v5xfda</bpmn:outgoing>
+          <bpmn:messageEventDefinition id="MessageEventDefinition_0ctx6uu" />
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_1v5xfda" sourceRef="MessageStartEvent_1" targetRef="RuleTask_1" />
+        <bpmn:businessRuleTask id="RuleTask_1" name="RuleTask_1">
+          <bpmn:extensionElements>
+            <zeebe:calledDecision resultVariable="toolResult" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_1v5xfda</bpmn:incoming>
+        </bpmn:businessRuleTask>
+      </bpmn:subProcess>
     </bpmn:adHocSubProcess>
     <bpmn:textAnnotation id="TextAnnotation_03j09jg">
-      <bpmn:text>outputElement: variable
-outputCollection: variables</bpmn:text>
+      <bpmn:text>outputElement: toolResult
+outputCollection: toolResults</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_0kjh134" associationDirection="None" sourceRef="AdHocSubProcess_1" targetRef="TextAnnotation_03j09jg" />
-    <bpmn:textAnnotation id="TextAnnotation_0tnxbjp">
-      <bpmn:text>outputElement: { variable: variable1 }
-outputCollection: variables</bpmn:text>
-    </bpmn:textAnnotation>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
-        <dc:Bounds x="310" y="190" width="350" height="200" />
+        <dc:Bounds x="160" y="190" width="360" height="370" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_11csst4_di" bpmnElement="Task_1">
-        <dc:Bounds x="430" y="250" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_03j09jg_di" bpmnElement="TextAnnotation_03j09jg">
-        <dc:Bounds x="590" y="80" width="219.99998474121094" height="41" />
+        <dc:Bounds x="220" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0kjh134_di" bpmnElement="Association_0kjh134">
-        <di:waypoint x="564" y="190" />
-        <di:waypoint x="619" y="121" />
+      <bpmndi:BPMNShape id="Activity_16tkphp_di" bpmnElement="ScriptTask_1">
+        <dc:Bounds x="360" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ytgz15_di" bpmnElement="EventSubProcess_1" isExpanded="true">
+        <dc:Bounds x="190" y="360" width="300" height="160" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tadlzf_di" bpmnElement="MessageStartEvent_1">
+        <dc:Bounds x="230" y="432" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="205" y="475" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00ao0ar_di" bpmnElement="RuleTask_1">
+        <dc:Bounds x="320" y="410" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1v5xfda_di" bpmnElement="Flow_1v5xfda">
+        <di:waypoint x="266" y="450" />
+        <di:waypoint x="320" y="450" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="BPMNShape_05hjquk" bpmnElement="TextAnnotation_0tnxbjp">
-        <dc:Bounds x="160" y="81" width="220" height="41" />
+      <bpmndi:BPMNEdge id="Association_0kjh134_di" bpmnElement="Association_0kjh134">
+        <di:waypoint x="414" y="190" />
+        <di:waypoint x="469" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_03j09jg_di" bpmnElement="TextAnnotation_03j09jg">
+        <dc:Bounds x="440" y="80" width="219.98794555664062" height="41" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn
+++ b/test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn
@@ -35,6 +35,14 @@
           <bpmn:incoming>Flow_1v5xfda</bpmn:incoming>
         </bpmn:businessRuleTask>
       </bpmn:subProcess>
+      <bpmn:scriptTask id="ScriptTask_2" name="ScriptTask_2&#10;&#10;Produce &#34;my@mail&#34;">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=&#34;my@mail&#34;" resultVariable="email" />
+          <zeebe:ioMapping>
+            <zeebe:output source="=email" target="toolResult.mail" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
     </bpmn:adHocSubProcess>
     <bpmn:textAnnotation id="TextAnnotation_03j09jg">
       <bpmn:text>outputElement: toolResult
@@ -45,7 +53,7 @@ outputCollection: toolResults</bpmn:text>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
-        <dc:Bounds x="160" y="190" width="360" height="370" />
+        <dc:Bounds x="160" y="190" width="480" height="370" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_11csst4_di" bpmnElement="Task_1">
         <dc:Bounds x="220" y="250" width="100" height="80" />
@@ -55,8 +63,12 @@ outputCollection: toolResults</bpmn:text>
         <dc:Bounds x="360" y="250" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1vg4byr" bpmnElement="ScriptTask_2">
+        <dc:Bounds x="500" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0ytgz15_di" bpmnElement="EventSubProcess_1" isExpanded="true">
-        <dc:Bounds x="190" y="360" width="300" height="160" />
+        <dc:Bounds x="190" y="360" width="410" height="160" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1tadlzf_di" bpmnElement="MessageStartEvent_1">
@@ -73,14 +85,14 @@ outputCollection: toolResults</bpmn:text>
         <di:waypoint x="266" y="450" />
         <di:waypoint x="320" y="450" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0kjh134_di" bpmnElement="Association_0kjh134">
-        <di:waypoint x="414" y="190" />
-        <di:waypoint x="469" y="121" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="TextAnnotation_03j09jg_di" bpmnElement="TextAnnotation_03j09jg">
         <dc:Bounds x="440" y="80" width="219.98794555664062" height="41" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0kjh134_di" bpmnElement="Association_0kjh134">
+        <di:waypoint x="414" y="190" />
+        <di:waypoint x="469" y="121" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn
+++ b/test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0-rc.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:adHocSubProcess id="SubProcess_1" name="SubProcess_1">
+    <bpmn:adHocSubProcess id="AdHocSubProcess_1" name="AdHocSubProcess_1">
       <bpmn:extensionElements>
         <zeebe:taskDefinition />
         <zeebe:adHoc outputCollection="variables" outputElement="=variable" />
@@ -22,7 +22,7 @@
       <bpmn:text>outputElement: variable
 outputCollection: variables</bpmn:text>
     </bpmn:textAnnotation>
-    <bpmn:association id="Association_0kjh134" associationDirection="None" sourceRef="SubProcess_1" targetRef="TextAnnotation_03j09jg" />
+    <bpmn:association id="Association_0kjh134" associationDirection="None" sourceRef="AdHocSubProcess_1" targetRef="TextAnnotation_03j09jg" />
     <bpmn:textAnnotation id="TextAnnotation_0tnxbjp">
       <bpmn:text>outputElement: { variable: variable1 }
 outputCollection: variables</bpmn:text>
@@ -30,7 +30,7 @@ outputCollection: variables</bpmn:text>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="SubProcess_1" isExpanded="true">
+      <bpmndi:BPMNShape id="Activity_0282riy_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
         <dc:Bounds x="310" y="190" width="350" height="200" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_11csst4_di" bpmnElement="Task_1">

--- a/test/zeebe/fixtures/script-task-result-variable-local.bpmn
+++ b/test/zeebe/fixtures/script-task-result-variable-local.bpmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:scriptTask id="Task_1" name="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=10" resultVariable="foo" />
+        <zeebe:ioMapping>
+          <zeebe:input target="foo" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="160" y="60" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/zeebe/fixtures/script-task-result-variable-output.bpmn
+++ b/test/zeebe/fixtures/script-task-result-variable-output.bpmn
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_14rdixd" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:scriptTask id="Task_1">
+    <bpmn:scriptTask id="Task_1" name="Task_1">
       <bpmn:extensionElements>
         <zeebe:script resultVariable="foo" />
         <zeebe:ioMapping>
           <zeebe:output target="bar" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Task_2" name="Task_2">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=false" resultVariable="ignored" />
+        <zeebe:ioMapping>
+          <zeebe:output target="foo" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:scriptTask>
@@ -14,8 +22,12 @@
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
         <dc:Bounds x="160" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1hq8aft" bpmnElement="Task_2">
+        <dc:Bounds x="310" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>
-

--- a/test/zeebe/fixtures/sub-process.nested-input-same-name.bpmn
+++ b/test/zeebe/fixtures/sub-process.nested-input-same-name.bpmn
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" name="SubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="= variable1" target="variable1" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:subProcess id="SubProcess_2" name="SubProcess_2">
+        <bpmn:extensionElements />
+        <bpmn:serviceTask id="Task_1" name="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:input source="= variable1" target="variable1" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:subProcess>
+    </bpmn:subProcess>
+    <bpmn:textAnnotation id="TextAnnotation_1ay710r">
+      <bpmn:text>in: variable3</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1371ih9" sourceRef="SubProcess_1" targetRef="TextAnnotation_1ay710r" />
+    <bpmn:association id="Association_0wzdk2p" associationDirection="None" sourceRef="TextAnnotation_1ay710r" targetRef="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1a3hnou_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="210" y="160" width="500" height="360" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11q7hbr_di" bpmnElement="SubProcess_2" isExpanded="true">
+        <dc:Bounds x="290" y="210" width="350" height="270" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15sbqp9_di" bpmnElement="Task_1">
+        <dc:Bounds x="410" y="340" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1371ih9_di" bpmnElement="Association_1371ih9">
+        <di:waypoint x="230" y="160" />
+        <di:waypoint x="214" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0wzdk2p_di" bpmnElement="Association_0wzdk2p">
+        <di:waypoint x="222" y="100" />
+        <di:waypoint x="414" y="342" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_1ay710r_di" bpmnElement="TextAnnotation_1ay710r">
+        <dc:Bounds x="160" y="70" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/zeebe/fixtures/sub-process.output-mapping-partial-names.bpmn
+++ b/test/zeebe/fixtures/sub-process.output-mapping-partial-names.bpmn
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdwtag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0-dev" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" name="SubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=variable3" target="variable3" />
+          <zeebe:input source="variable4.wap" target="variable4.wap" />
+          <zeebe:output source="=variable3" target="variable3" />
+          <zeebe:output source="=variable2.foo" target="variable2.foo" />
+          <zeebe:output source="=variable2.bar" target="variable2.bar" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1ocwri9</bpmn:incoming>
+      <bpmn:scriptTask id="Task_2" name="Task_2">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:output source="=&#34;variable3.woop :: Task_2&#34;" target="variable3.woop" />
+            <zeebe:output source="=&#34;variable2.foo :: Task_2&#34;" target="variable2.foo" />
+            <zeebe:output source="=&#34;variable4.wap :: Task_2&#34;" target="variable4.wap" />
+            <zeebe:output source="=&#34;variable4.other :: Task_2&#34;" target="variable4.other" />
+          </zeebe:ioMapping>
+          <zeebe:script expression="=false" resultVariable="ignored" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_18sfa7t</bpmn:incoming>
+      </bpmn:scriptTask>
+      <bpmn:startEvent id="Event_15bvfqn">
+        <bpmn:outgoing>Flow_18sfa7t</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_18sfa7t" sourceRef="Event_15bvfqn" targetRef="Task_2" />
+    </bpmn:subProcess>
+    <bpmn:startEvent id="Event_0ow5vi3">
+      <bpmn:outgoing>Flow_0gas850</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0gas850" sourceRef="Event_0ow5vi3" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_1ocwri9" sourceRef="Task_1" targetRef="SubProcess_1" />
+    <bpmn:scriptTask id="Task_1" name="Task_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=&#34;variable1.foo :: Task_1&#34;" target="variable1.foo" />
+          <zeebe:output source="=&#34;variable2.foo :: Task_1&#34;" target="variable2.foo" />
+        </zeebe:ioMapping>
+        <zeebe:script expression="=false" resultVariable="ignored" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0gas850</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ocwri9</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:textAnnotation id="TextAnnotation_1w05j7t">
+      <bpmn:text>out: variable1.foo
+out: variable2.foo</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1f5ibn0" associationDirection="None" sourceRef="TextAnnotation_1w05j7t" targetRef="Task_1" />
+    <bpmn:textAnnotation id="TextAnnotation_0r08blm">
+      <bpmn:text>in: variable3
+in: variable4.wap</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="TextAnnotation_1000ukx">
+      <bpmn:text>out: variable3
+out: variable2.foo
+out: variable2.bar</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_1ia6qx5" associationDirection="None" sourceRef="TextAnnotation_0r08blm" targetRef="SubProcess_1" />
+    <bpmn:association id="Association_0drk835" associationDirection="None" sourceRef="TextAnnotation_1000ukx" targetRef="SubProcess_1" />
+    <bpmn:textAnnotation id="TextAnnotation_1n7vsfl">
+      <bpmn:text>out: variable3.woop
+out: variable2.foo
+out: variable4.wap
+out: variable4.other</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="TextAnnotation_0z84pzz">
+      <bpmn:text>declares both &lt;variable3&gt; and &lt;variable4&gt; as local (!)</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_17wdtdq" associationDirection="None" sourceRef="SubProcess_1" targetRef="TextAnnotation_0z84pzz" />
+    <bpmn:association id="Association_0zktzid" associationDirection="None" sourceRef="TextAnnotation_1n7vsfl" targetRef="Task_2" />
+    <bpmn:textAnnotation id="TextAnnotation_08ir8bp">
+      <bpmn:text>Maps &lt;variable2.foo&gt; to itself (access global variable)</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_08ofybf" associationDirection="None" sourceRef="TextAnnotation_08ir8bp" targetRef="SubProcess_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_0ow5vi3_di" bpmnElement="Event_0ow5vi3">
+        <dc:Bounds x="152" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0c0vh6v_di" bpmnElement="Task_1">
+        <dc:Bounds x="250" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11q7hbr_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="430" y="290" width="300" height="180" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01n77ai_di" bpmnElement="Task_2">
+        <dc:Bounds x="550" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_15bvfqn_di" bpmnElement="Event_15bvfqn">
+        <dc:Bounds x="472" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_18sfa7t_di" bpmnElement="Flow_18sfa7t">
+        <di:waypoint x="508" y="390" />
+        <di:waypoint x="550" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1f5ibn0_di" bpmnElement="Association_1f5ibn0">
+        <di:waypoint x="265" y="270" />
+        <di:waypoint x="288" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ia6qx5_di" bpmnElement="Association_1ia6qx5">
+        <di:waypoint x="423" y="236" />
+        <di:waypoint x="449" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0drk835_di" bpmnElement="Association_0drk835">
+        <di:waypoint x="850" y="202" />
+        <di:waypoint x="728" y="295" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_17wdtdq_di" bpmnElement="Association_17wdtdq">
+        <di:waypoint x="480" y="290" />
+        <di:waypoint x="494" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0zktzid_di" bpmnElement="Association_0zktzid">
+        <di:waypoint x="686" y="520" />
+        <di:waypoint x="644" y="429" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_08ofybf_di" bpmnElement="Association_08ofybf">
+        <di:waypoint x="840" y="293" />
+        <di:waypoint x="730" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_1w05j7t_di" bpmnElement="TextAnnotation_1w05j7t">
+        <dc:Bounds x="160" y="230" width="150" height="40" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_04wthyh" bpmnElement="TextAnnotation_0r08blm">
+        <dc:Bounds x="360" y="196" width="110" height="40" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_193wgrs" bpmnElement="TextAnnotation_1000ukx">
+        <dc:Bounds x="850" y="150" width="160" height="54.999996185302734" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kp3q2k" bpmnElement="TextAnnotation_1n7vsfl">
+        <dc:Bounds x="660" y="520" width="160" height="70" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0z84pzz_di" bpmnElement="TextAnnotation_0z84pzz" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="450" y="80" width="100" height="70" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0gas850_di" bpmnElement="Flow_0gas850">
+        <di:waypoint x="188" y="390" />
+        <di:waypoint x="250" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ocwri9_di" bpmnElement="Flow_1ocwri9">
+        <di:waypoint x="350" y="390" />
+        <di:waypoint x="430" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_0neskj4" bpmnElement="TextAnnotation_08ir8bp" bioc:stroke="#0d4372" bioc:fill="#bbdefb" color:background-color="#bbdefb" color:border-color="#0d4372">
+        <dc:Bounds x="840" y="250" width="110" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/zeebe/fixtures/sub-process.same-name-different-scope.bpmn
+++ b/test/zeebe/fixtures/sub-process.same-name-different-scope.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_003vix6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_1" name="Process_1" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_1" name="SubProcess_1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=variable1" target="variable1" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:serviceTask id="Task_1" name="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input source="=variable1" target="variable1" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>
+    <bpmn:textAnnotation id="TextAnnotation_08tjazu">
+      <bpmn:text>in: variable1 -&gt; variable1</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0qac0ze" associationDirection="None" sourceRef="TextAnnotation_08tjazu" targetRef="SubProcess_1" />
+    <bpmn:association id="Association_0i6s9ub" associationDirection="None" sourceRef="TextAnnotation_08tjazu" targetRef="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="BPMNShape_1k5qbcs" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds x="270" y="250" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1526aw8" bpmnElement="Task_1">
+        <dc:Bounds x="370" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_199jo5i" bpmnElement="Association_0i6s9ub">
+        <di:waypoint x="215" y="155" />
+        <di:waypoint x="371" y="307" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0qac0ze_di" bpmnElement="Association_0qac0ze">
+        <di:waypoint x="213" y="155" />
+        <di:waypoint x="277" y="251" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1dagjjz" bpmnElement="TextAnnotation_08tjazu">
+        <dc:Bounds x="180" y="120" width="209.98794555664062" height="35" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 
-import { sortBy, map } from 'min-dash';
+import { sortBy } from 'min-dash';
 
-import { BpmnModdle } from 'bpmn-moddle';
-
-import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json' with { type: 'json' };
-
-import fs from 'fs';
+import {
+  convertToTestable,
+  getRootElement,
+  readModel
+} from '../TestHelper.js';
 
 import {
   getProcessVariables,
@@ -22,11 +22,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / simple', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/simple.bpmn');
+      const model = await readModel('test/zeebe/fixtures/simple.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -43,11 +41,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / sub process', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -64,11 +60,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / sub process / duplicated vars', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.duplicates.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.duplicates.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -85,11 +79,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / sub process / own scope', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -106,11 +98,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / input mapping / same name', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.same-name-different-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.same-name-different-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -126,11 +116,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / sub process / own scope / duplicates', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope-duplicates.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope-duplicates.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -148,11 +136,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / sub process / output mapping', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.output-mapping.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.output-mapping.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -170,11 +156,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / sub process / nested sub process', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.nested.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.nested.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -191,11 +175,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / additional extractors', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/simple.bpmn');
+      const model = await readModel('test/zeebe/fixtures/simple.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement, [
@@ -216,11 +198,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / additional extractors / async', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/simple.bpmn');
+      const model = await readModel('test/zeebe/fixtures/simple.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement, [
@@ -241,11 +221,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / script task / result variable, output exists', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/script-task-result-variable-output.bpmn');
+      const model = await readModel('test/zeebe/fixtures/script-task-result-variable-output.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -261,11 +239,9 @@ describe('zeebe/process variables module', function() {
     it('should not extract variables / script task / result variable, output exists with same name', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/script-task-result-variable-output-same-name.bpmn');
+      const model = await readModel('test/zeebe/fixtures/script-task-result-variable-output-same-name.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -280,11 +256,9 @@ describe('zeebe/process variables module', function() {
     it('should handle errors gracefully', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/errors.bpmn');
+      const model = await readModel('test/zeebe/fixtures/errors.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getProcessVariables(rootElement);
@@ -301,11 +275,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / process', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForScope('Process_1', rootElement);
@@ -321,11 +293,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / sub process', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
@@ -346,11 +316,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / ad-hoc sub process', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.ad-hoc.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
@@ -370,11 +338,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / ad-hoc sub process / own scope', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.ad-hoc-own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc-own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
@@ -394,11 +360,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / multi-instance sub process', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.multi-instance.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.multi-instance.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
@@ -418,11 +382,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / multi-instance sub process / own scope', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.multi-instance-own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.multi-instance-own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
@@ -442,11 +404,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / additional extractors', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForScope('Process_1', rootElement, [
@@ -466,11 +426,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / additional extractors (async)', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForScope('Process_1', rootElement, [
@@ -494,11 +452,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / process', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForElement(rootElement);
@@ -514,11 +470,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / sub process', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       const subProcess = rootElement.flowElements[0];
 
@@ -541,11 +495,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / additional extractors', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForElement(rootElement, [
@@ -565,11 +517,9 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / additional extractors (async)', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       // when
       const variables = await getVariablesForElement(rootElement, [
@@ -589,42 +539,12 @@ describe('zeebe/process variables module', function() {
 
 });
 
+
 // helpers //////////
-
-function getRootElement(definitions) {
-  return definitions.get('rootElements')[0];
-}
-
-async function parse(xml) {
-  const moddle = new BpmnModdle({
-    zeebe: ZeebeModdle,
-  });
-
-  const { rootElement: definitions } = await moddle.fromXML(xml);
-
-  return definitions;
-}
-
-function read(path, encoding = 'utf8') {
-  return fs.readFileSync(path, encoding);
-}
 
 function sortVariablesByName(variables) {
   return sortBy(variables, function(variable) {
     return variable.name;
-  });
-}
-
-// converts the variables list from full moddle elements to only id, for better testability
-function convertToTestable(variables) {
-  return map(variables, function(variable) {
-    return {
-      name: variable.name,
-      origin: map(variable.origin, function(origin) {
-        return origin.id;
-      }),
-      scope: variable.scope.id
-    };
   });
 }
 

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -399,6 +399,13 @@ describe('zeebe/process variables module', function() {
           ],
           scope: 'AdHocSubProcess_1'
         },
+        {
+          name: 'toolResult.mail',
+          origin: [
+            'ScriptTask_2'
+          ],
+          scope: 'AdHocSubProcess_1'
+        },
         { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
       ]);
     });

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -248,7 +248,25 @@ describe('zeebe/process variables module', function() {
 
       // then
       expect(convertToTestable(variables)).to.eql([
-        { name: 'foo', origin: [ 'Task_1' ], scope: 'Process_1' }
+        { name: 'foo', origin: [ 'Task_1' ], scope: 'Process_1' },
+        { name: 'foo', origin: [ 'Task_1' ], scope: 'Task_1' }
+      ]);
+    });
+
+
+    it('should extract variables / script task / result variable / local', async function() {
+
+      // given
+      const model = await readModel('test/zeebe/fixtures/script-task-result-variable-local.bpmn');
+
+      const rootElement = getRootElement(model);
+
+      // when
+      const variables = await getProcessVariables(rootElement);
+
+      // then
+      expect(convertToTestable(variables)).to.eql([
+        { name: 'foo', origin: [ 'Task_1' ], scope: 'Task_1' }
       ]);
     });
 

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -387,8 +387,17 @@ describe('zeebe/process variables module', function() {
 
       // own + all variables from parent scope
       expect(convertToTestable(sortedVariables)).to.eql([
-        { name: 'variable', origin: [ 'AdHocSubProcess_1', 'Task_1' ], scope: 'AdHocSubProcess_1' },
-        { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
+        {
+          name: 'toolResult',
+          origin: [
+            'AdHocSubProcess_1',
+            'Task_1',
+            'ScriptTask_1',
+            'RuleTask_1'
+          ],
+          scope: 'AdHocSubProcess_1'
+        },
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
       ]);
     });
 

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -249,7 +249,9 @@ describe('zeebe/process variables module', function() {
       // then
       expect(convertToTestable(variables)).to.eql([
         { name: 'bar', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'foo', origin: [ 'Task_1' ], scope: 'Task_1' }
+        { name: 'foo', origin: [ 'Task_2' ], scope: 'Process_1' },
+        { name: 'foo', origin: [ 'Task_1' ], scope: 'Task_1' },
+        { name: 'ignored', origin: [ 'Task_2' ], scope: 'Task_2' }
       ]);
     });
 

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -172,6 +172,24 @@ describe('zeebe/process variables module', function() {
     });
 
 
+    it('should extract variables / sub process / nested sub process / duplicate inputs', async function() {
+
+      // given
+      const model = await readModel('test/zeebe/fixtures/sub-process.nested-input-same-name.bpmn');
+
+      const rootElement = getRootElement(model);
+
+      // when
+      const variables = await getProcessVariables(rootElement);
+
+      // then
+      expect(convertToTestable(variables)).to.eql([
+        { name: 'variable1', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' },
+        { name: 'variable1', origin: [ 'Task_1' ], scope: 'Task_1' }
+      ]);
+    });
+
+
     it('should extract variables / additional extractors', async function() {
 
       // given

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -404,6 +404,36 @@ describe('zeebe/process variables module', function() {
     });
 
 
+    it('should extract variables / ad-hoc sub process / nested partial writes', async function() {
+
+      // given
+      const model = await readModel('test/zeebe/fixtures/ad-hoc-sub-process.nested-partial-writes.bpmn');
+
+      const rootElement = getRootElement(model);
+
+      // when
+      const variables = await getVariablesForScope('AdHocSubProcess_1', rootElement);
+
+      const sortedVariables = sortVariablesByName(variables);
+
+      // then
+
+      // own + all variables from parent scope
+      expect(convertToTestable(sortedVariables)).to.eql([
+        {
+          name: 'toolResult',
+          origin: [
+            'AdHocSubProcess_1',
+            'ScriptTask_1',
+          ],
+          scope: 'AdHocSubProcess_1'
+        },
+        { name: 'toolResult.email', origin: [ 'ScriptTask_2' ], scope: 'AdHocSubProcess_1' },
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
+      ]);
+    });
+
+
     it('should extract variables / multi-instance sub process', async function() {
 
       // given

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -103,6 +103,26 @@ describe('zeebe/process variables module', function() {
     });
 
 
+    it('should extract variables / input mapping / same name', async function() {
+
+      // given
+      const xml = read('test/zeebe/fixtures/sub-process.same-name-different-scope.bpmn');
+
+      const definitions = await parse(xml);
+
+      const rootElement = getRootElement(definitions);
+
+      // when
+      const variables = await getProcessVariables(rootElement);
+
+      // then
+      expect(convertToTestable(variables)).to.eql([
+        { name: 'variable1', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' },
+        { name: 'variable1', origin: [ 'Task_1' ], scope: 'Task_1' }
+      ]);
+    });
+
+
     it('should extract variables / sub process / own scope / duplicates', async function() {
 
       // given

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -352,12 +352,12 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / ad-hoc sub process', async function() {
 
       // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc.bpmn');
+      const model = await readModel('test/zeebe/fixtures/ad-hoc-sub-process.bpmn');
 
       const rootElement = getRootElement(model);
 
       // when
-      const variables = await getVariablesForScope('SubProcess_1', rootElement);
+      const variables = await getVariablesForScope('AdHocSubProcess_1', rootElement);
 
       const sortedVariables = sortVariablesByName(variables);
 
@@ -366,7 +366,7 @@ describe('zeebe/process variables module', function() {
       // own + all variables from parent scope
       expect(convertToTestable(sortedVariables)).to.eql([
         { name: 'variable', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'variables', origin: [ 'SubProcess_1' ], scope: 'Process_1' }
+        { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'Process_1' }
       ]);
     });
 
@@ -374,12 +374,12 @@ describe('zeebe/process variables module', function() {
     it('should extract variables / ad-hoc sub process / own scope', async function() {
 
       // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc-own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn');
 
       const rootElement = getRootElement(model);
 
       // when
-      const variables = await getVariablesForScope('SubProcess_1', rootElement);
+      const variables = await getVariablesForScope('AdHocSubProcess_1', rootElement);
 
       const sortedVariables = sortVariablesByName(variables);
 
@@ -387,8 +387,8 @@ describe('zeebe/process variables module', function() {
 
       // own + all variables from parent scope
       expect(convertToTestable(sortedVariables)).to.eql([
-        { name: 'variable', origin: [ 'SubProcess_1', 'Task_1' ], scope: 'SubProcess_1' },
-        { name: 'variables', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' }
+        { name: 'variable', origin: [ 'AdHocSubProcess_1', 'Task_1' ], scope: 'AdHocSubProcess_1' },
+        { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
       ]);
     });
 

--- a/test/zeebe/spec/extractors/extractInputElementSpec.js
+++ b/test/zeebe/spec/extractors/extractInputElementSpec.js
@@ -1,16 +1,9 @@
 import { expect } from 'chai';
 
-import { map } from 'min-dash';
-
-import { BpmnModdle } from 'bpmn-moddle';
-
-import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json' with { type: 'json' };
-
-import fs from 'fs';
-
 import extractVariables from '../../../../src/zeebe/extractors/extractInputElement.js';
 
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
+import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
 describe('zeebe/extractors - input element', function() {
@@ -18,11 +11,9 @@ describe('zeebe/extractors - input element', function() {
   it('should extract variables from input elements', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/sub-process.multi-instance.bpmn');
+    const model = await readModel('test/zeebe/fixtures/sub-process.multi-instance.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -43,11 +34,9 @@ describe('zeebe/extractors - input element', function() {
   it('should not extract variables from empty loopCharacteristics', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/sub-process.multi-instance-empty.bpmn');
+    const model = await readModel('test/zeebe/fixtures/sub-process.multi-instance-empty.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -63,37 +52,3 @@ describe('zeebe/extractors - input element', function() {
   });
 
 });
-
-
-// helpers //////////
-
-function getRootElement(definitions) {
-  return definitions.get('rootElements')[0];
-}
-
-async function parse(xml) {
-  const moddle = new BpmnModdle({
-    zeebe: ZeebeModdle,
-  });
-
-  const { rootElement: definitions } = await moddle.fromXML(xml);
-
-  return definitions;
-}
-
-function read(path, encoding = 'utf8') {
-  return fs.readFileSync(path, encoding);
-}
-
-// converts the variables list from full moddle elements to only id, for better testability
-function convertToTestable(variables) {
-  return map(variables, function(variable) {
-    return {
-      name: variable.name,
-      origin: map(variable.origin, function(origin) {
-        return origin.id;
-      }),
-      scope: variable.scope.id
-    };
-  });
-}

--- a/test/zeebe/spec/extractors/extractInputMappingsSpec.js
+++ b/test/zeebe/spec/extractors/extractInputMappingsSpec.js
@@ -1,16 +1,9 @@
 import { expect } from 'chai';
 
-import { map } from 'min-dash';
-
-import { BpmnModdle } from 'bpmn-moddle';
-
-import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json' with { type: 'json' };
-
-import fs from 'fs';
-
 import extractVariables from '../../../../src/zeebe/extractors/extractInputMappings.js';
 
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
+import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
 describe('zeebe/extractors - input mappings', function() {
@@ -18,11 +11,9 @@ describe('zeebe/extractors - input mappings', function() {
   it('should extract variables from in mappings', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/sub-process.input-mapping.bpmn');
+    const model = await readModel('test/zeebe/fixtures/sub-process.input-mapping.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -44,11 +35,9 @@ describe('zeebe/extractors - input mappings', function() {
   it('should ignore invalid input mapping', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/errors.bpmn');
+    const model = await readModel('test/zeebe/fixtures/errors.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -64,37 +53,3 @@ describe('zeebe/extractors - input mappings', function() {
   });
 
 });
-
-
-// helpers //////////
-
-function getRootElement(definitions) {
-  return definitions.get('rootElements')[0];
-}
-
-async function parse(xml) {
-  const moddle = new BpmnModdle({
-    zeebe: ZeebeModdle,
-  });
-
-  const { rootElement: definitions } = await moddle.fromXML(xml);
-
-  return definitions;
-}
-
-function read(path, encoding = 'utf8') {
-  return fs.readFileSync(path, encoding);
-}
-
-// converts the variables list from full moddle elements to only id, for better testability
-function convertToTestable(variables) {
-  return map(variables, function(variable) {
-    return {
-      name: variable.name,
-      origin: map(variable.origin, function(origin) {
-        return origin.id;
-      }),
-      scope: variable.scope.id
-    };
-  });
-}

--- a/test/zeebe/spec/extractors/extractInputMappingsSpec.js
+++ b/test/zeebe/spec/extractors/extractInputMappingsSpec.js
@@ -8,7 +8,7 @@ import { convertToTestable, getRootElement, readModel } from '../../TestHelper.j
 
 describe('zeebe/extractors - input mappings', function() {
 
-  it('should extract variables from in mappings', async function() {
+  it('should extract variables for sub-process', async function() {
 
     // given
     const model = await readModel('test/zeebe/fixtures/sub-process.input-mapping.bpmn');
@@ -28,6 +28,29 @@ describe('zeebe/extractors - input mappings', function() {
     expect(convertToTestable(variables)).to.eql([
       { name: 'variable1', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' },
       { name: 'variable2', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' },
+    ]);
+  });
+
+
+  it('should extract variables for task', async function() {
+
+    // given
+    const model = await readModel('test/zeebe/fixtures/script-task-result-variable-local.bpmn');
+
+    const rootElement = getRootElement(model);
+
+    const elements = selfAndAllFlowElements([ rootElement ], false);
+
+    // when
+    const variables = extractVariables({
+      elements,
+      containerElement: rootElement,
+      processVariables: []
+    });
+
+    // then
+    expect(convertToTestable(variables)).to.eql([
+      { name: 'foo', origin: [ 'Task_1' ], scope: 'Task_1' }
     ]);
   });
 

--- a/test/zeebe/spec/extractors/extractInputMappingsSpec.js
+++ b/test/zeebe/spec/extractors/extractInputMappingsSpec.js
@@ -32,6 +32,30 @@ describe('zeebe/extractors - input mappings', function() {
   });
 
 
+  it('should extract variables for sub-process / nested', async function() {
+
+    // given
+    const model = await readModel('test/zeebe/fixtures/sub-process.nested-input-same-name.bpmn');
+
+    const rootElement = getRootElement(model);
+
+    const elements = selfAndAllFlowElements([ rootElement ], false);
+
+    // when
+    const variables = extractVariables({
+      elements,
+      containerElement: rootElement,
+      processVariables: []
+    });
+
+    // then
+    expect(convertToTestable(variables)).to.eql([
+      { name: 'variable1', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' },
+      { name: 'variable1', origin: [ 'Task_1' ], scope: 'Task_1' },
+    ]);
+  });
+
+
   it('should extract variables for task', async function() {
 
     // given

--- a/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
@@ -61,7 +61,7 @@ describe('zeebe/extractors - output collections', function() {
     it('should extract variables', async function() {
 
       // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc.bpmn');
+      const model = await readModel('test/zeebe/fixtures/ad-hoc-sub-process.bpmn');
 
       const rootElement = getRootElement(model);
 
@@ -76,7 +76,7 @@ describe('zeebe/extractors - output collections', function() {
 
       // then
       expect(convertToTestable(variables)).to.eql([
-        { name: 'variables', origin: [ 'SubProcess_1' ], scope: 'Process_1' }
+        { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'Process_1' }
       ]);
     });
 
@@ -84,7 +84,7 @@ describe('zeebe/extractors - output collections', function() {
     it('should extract variables / scoped', async function() {
 
       // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc-own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn');
 
       const rootElement = getRootElement(model);
 
@@ -99,15 +99,15 @@ describe('zeebe/extractors - output collections', function() {
 
       // then
       expect(convertToTestable(variables)).to.eql([
-        { name: 'variables', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' }
+        { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
       ]);
     });
 
 
-    it('should not extract variables / empty loopCharacteristics', async function() {
+    it('should not extract variables / missing output collection', async function() {
 
       // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc-empty.bpmn');
+      const model = await readModel('test/zeebe/fixtures/ad-hoc-sub-process.no-output-collection.bpmn');
 
       const rootElement = getRootElement(model);
 

--- a/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
@@ -99,7 +99,7 @@ describe('zeebe/extractors - output collections', function() {
 
       // then
       expect(convertToTestable(variables)).to.eql([
-        { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
       ]);
     });
 

--- a/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
@@ -1,16 +1,9 @@
 import { expect } from 'chai';
 
-import { map } from 'min-dash';
-
-import { BpmnModdle } from 'bpmn-moddle';
-
-import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json' with { type: 'json' };
-
-import fs from 'fs';
-
 import extractVariables from '../../../../src/zeebe/extractors/extractOutputCollections.js';
 
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
+import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
 describe('zeebe/extractors - output collections', function() {
@@ -20,11 +13,9 @@ describe('zeebe/extractors - output collections', function() {
     it('should extract variables', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.multi-instance.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.multi-instance.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -45,11 +36,9 @@ describe('zeebe/extractors - output collections', function() {
     it('should not extract variables / empty loopCharacteristics', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.multi-instance-empty.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.multi-instance-empty.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -72,11 +61,9 @@ describe('zeebe/extractors - output collections', function() {
     it('should extract variables', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.ad-hoc.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -97,11 +84,9 @@ describe('zeebe/extractors - output collections', function() {
     it('should extract variables / scoped', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.ad-hoc-own-scope.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc-own-scope.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -122,11 +107,9 @@ describe('zeebe/extractors - output collections', function() {
     it('should not extract variables / empty loopCharacteristics', async function() {
 
       // given
-      const xml = read('test/zeebe/fixtures/sub-process.ad-hoc-empty.bpmn');
+      const model = await readModel('test/zeebe/fixtures/sub-process.ad-hoc-empty.bpmn');
 
-      const definitions = await parse(xml);
-
-      const rootElement = getRootElement(definitions);
+      const rootElement = getRootElement(model);
 
       const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -144,37 +127,3 @@ describe('zeebe/extractors - output collections', function() {
   });
 
 });
-
-
-// helpers //////////
-
-function getRootElement(definitions) {
-  return definitions.get('rootElements')[0];
-}
-
-async function parse(xml) {
-  const moddle = new BpmnModdle({
-    zeebe: ZeebeModdle,
-  });
-
-  const { rootElement: definitions } = await moddle.fromXML(xml);
-
-  return definitions;
-}
-
-function read(path, encoding = 'utf8') {
-  return fs.readFileSync(path, encoding);
-}
-
-// converts the variables list from full moddle elements to only id, for better testability
-function convertToTestable(variables) {
-  return map(variables, function(variable) {
-    return {
-      name: variable.name,
-      origin: map(variable.origin, function(origin) {
-        return origin.id;
-      }),
-      scope: variable.scope.id
-    };
-  });
-}

--- a/test/zeebe/spec/extractors/extractOutputMappingsSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputMappingsSpec.js
@@ -58,6 +58,35 @@ describe('zeebe/extractors - output mappings', function() {
   });
 
 
+  it('should extract variables / sub process / partial names', async function() {
+
+    // given
+    const model = await readModel('test/zeebe/fixtures/sub-process.output-mapping-partial-names.bpmn');
+
+    const rootElement = getRootElement(model);
+
+    const elements = selfAndAllFlowElements([ rootElement ], false);
+
+    // when
+    const variables = extractVariables({
+      elements,
+      containerElement: rootElement,
+      processVariables: []
+    });
+
+    // then
+    expect(convertToTestable(variables)).to.eql([
+      { name: 'variable3', origin: [ 'SubProcess_1' ], scope: 'Process_1' },
+      { name: 'variable2.foo', origin: [ 'SubProcess_1', 'Task_2', 'Task_1' ], scope: 'Process_1' },
+      { name: 'variable2.bar', origin: [ 'SubProcess_1' ], scope: 'Process_1' },
+      { name: 'variable3.woop', origin: [ 'Task_2' ], scope: 'SubProcess_1' },
+      { name: 'variable4.wap', origin: [ 'Task_2' ], scope: 'SubProcess_1' },
+      { name: 'variable4.other', origin: [ 'Task_2' ], scope: 'SubProcess_1' },
+      { name: 'variable1.foo', origin: [ 'Task_1' ], scope: 'Process_1' }
+    ]);
+  });
+
+
   it('should ignore invalid output mapping', async function() {
 
     // given

--- a/test/zeebe/spec/extractors/extractOutputMappingsSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputMappingsSpec.js
@@ -1,16 +1,9 @@
 import { expect } from 'chai';
 
-import { map } from 'min-dash';
-
-import { BpmnModdle } from 'bpmn-moddle';
-
-import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json' with { type: 'json' };
-
-import fs from 'fs';
-
 import extractVariables from '../../../../src/zeebe/extractors/extractOutputMappings.js';
 
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
+import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
 describe('zeebe/extractors - output mappings', function() {
@@ -18,11 +11,9 @@ describe('zeebe/extractors - output mappings', function() {
   it('should extract variables / simple', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/simple.bpmn');
+    const model = await readModel('test/zeebe/fixtures/simple.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -44,11 +35,9 @@ describe('zeebe/extractors - output mappings', function() {
   it('should extract variables / sub process', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/sub-process.output-mapping.bpmn');
+    const model = await readModel('test/zeebe/fixtures/sub-process.output-mapping.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -72,11 +61,9 @@ describe('zeebe/extractors - output mappings', function() {
   it('should ignore invalid output mapping', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/errors.bpmn');
+    const model = await readModel('test/zeebe/fixtures/errors.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -90,38 +77,5 @@ describe('zeebe/extractors - output mappings', function() {
     // then
     expect(convertToTestable(variables)).to.eql([]);
   });
+
 });
-
-
-// helpers //////////
-
-function getRootElement(definitions) {
-  return definitions.get('rootElements')[0];
-}
-
-async function parse(xml) {
-  const moddle = new BpmnModdle({
-    zeebe: ZeebeModdle,
-  });
-
-  const { rootElement: definitions } = await moddle.fromXML(xml);
-
-  return definitions;
-}
-
-function read(path, encoding = 'utf8') {
-  return fs.readFileSync(path, encoding);
-}
-
-// converts the variables list from full moddle elements to only id, for better testability
-function convertToTestable(variables) {
-  return map(variables, function(variable) {
-    return {
-      name: variable.name,
-      origin: map(variable.origin, function(origin) {
-        return origin.id;
-      }),
-      scope: variable.scope.id
-    };
-  });
-}

--- a/test/zeebe/spec/extractors/extractResultVariablesSpec.js
+++ b/test/zeebe/spec/extractors/extractResultVariablesSpec.js
@@ -31,7 +31,7 @@ describe('zeebe/extractors - result variables', function() {
   });
 
 
-  it('should extract variables from script', async function() {
+  it('should extract variables from script / global variable', async function() {
 
     // given
     const model = await readModel('test/zeebe/fixtures/script-task-result-variable.bpmn');
@@ -50,6 +50,29 @@ describe('zeebe/extractors - result variables', function() {
     // then
     expect(convertToTestable(variables)).to.eql([
       { name: 'resultVariable', origin: [ 'Task_1' ], scope: 'Process_1' }
+    ]);
+  });
+
+
+  it('should extract variables from script / local variable', async function() {
+
+    // given
+    const model = await readModel('test/zeebe/fixtures/script-task-result-variable-local.bpmn');
+
+    const rootElement = getRootElement(model);
+
+    const elements = selfAndAllFlowElements([ rootElement ], false);
+
+    // when
+    const variables = extractVariables({
+      elements,
+      containerElement: rootElement,
+      processVariables: []
+    });
+
+    // then
+    expect(convertToTestable(variables)).to.eql([
+      { name: 'foo', origin: [ 'Task_1' ], scope: 'Task_1' }
     ]);
   });
 

--- a/test/zeebe/spec/extractors/extractResultVariablesSpec.js
+++ b/test/zeebe/spec/extractors/extractResultVariablesSpec.js
@@ -1,16 +1,9 @@
 import { expect } from 'chai';
 
-import { map } from 'min-dash';
-
-import { BpmnModdle } from 'bpmn-moddle';
-
-import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe.json' with { type: 'json' };
-
-import fs from 'fs';
-
 import extractVariables from '../../../../src/zeebe/extractors/extractResultVariables.js';
 
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
+import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
 describe('zeebe/extractors - result variables', function() {
@@ -18,11 +11,9 @@ describe('zeebe/extractors - result variables', function() {
   it('should extract variables from called decision', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/business-rule-task-result-variable.bpmn');
+    const model = await readModel('test/zeebe/fixtures/business-rule-task-result-variable.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -43,11 +34,9 @@ describe('zeebe/extractors - result variables', function() {
   it('should extract variables from script', async function() {
 
     // given
-    const xml = read('test/zeebe/fixtures/script-task-result-variable.bpmn');
+    const model = await readModel('test/zeebe/fixtures/script-task-result-variable.bpmn');
 
-    const definitions = await parse(xml);
-
-    const rootElement = getRootElement(definitions);
+    const rootElement = getRootElement(model);
 
     const elements = selfAndAllFlowElements([ rootElement ], false);
 
@@ -65,37 +54,3 @@ describe('zeebe/extractors - result variables', function() {
   });
 
 });
-
-
-// helpers //////////
-
-function getRootElement(definitions) {
-  return definitions.get('rootElements')[0];
-}
-
-async function parse(xml) {
-  const moddle = new BpmnModdle({
-    zeebe: ZeebeModdle,
-  });
-
-  const { rootElement: definitions } = await moddle.fromXML(xml);
-
-  return definitions;
-}
-
-function read(path, encoding = 'utf8') {
-  return fs.readFileSync(path, encoding);
-}
-
-// converts the variables list from full moddle elements to only id, for better testability
-function convertToTestable(variables) {
-  return map(variables, function(variable) {
-    return {
-      name: variable.name,
-      origin: map(variable.origin, function(origin) {
-        return origin.id;
-      }),
-      scope: variable.scope.id
-    };
-  });
-}


### PR DESCRIPTION
### Proposed Changes

> [!NOTE] 
> Does not ship any breaking changes in `@bpmn-io/variable-resolver` (validated via local linking).

Corrects two issues with `Zeebe` variable extraction, not properly account for the scoping rules of the engine:

* An input mapping _always_ creates a local scope (https://github.com/bpmn-io/extract-process-variables/commit/41859724a62cd357b68c45ba7e89dbb4b4d788b8)

  ![capture yGSRAh_optimized](https://github.com/user-attachments/assets/836b58c8-7425-49fe-9cd8-3d8e3e167eca)

  
* `resultVariable` would not properly work with local scope (https://github.com/bpmn-io/extract-process-variables/commit/d126c92c24a0c5754c728e91bfc93112d872c2ef)

  ![capture zL6E4Z_optimized](https://github.com/user-attachments/assets/f6e3d8f8-33f1-4a8a-832c-839fdc615b95)

In addition, it adds support for output mappings with paths, writing partial variables, and being used in official agentic examples.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
