### PR TITLE
Expose `getScope` and additional improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ ___Note:__ Yet to be released changes appear here._
 ## 2.2.0
 
 * `FEAT`: recognize output mapping variables with paths ([#35](https://github.com/bpmn-io/extract-process-variables/pull/35))
+* `FEAT`: expose `getScope` for use by downstream integrators ([#36](https://github.com/bpmn-io/extract-process-variables/pull/36))
 * `FIX`: correctly recognize local `resultVariable` ([#35](https://github.com/bpmn-io/extract-process-variables/pull/35))
 * `FIX`: ensure input mapping always creates local scope ([#35](https://github.com/bpmn-io/extract-process-variables/pull/35))
+* `CHORE`: align scope detection across Camunda 7 and Camunda 8 ([#36](https://github.com/bpmn-io/extract-process-variables/pull/36))
 
 ## 2.1.1
 

--- a/src/camunda-platform/index.js
+++ b/src/camunda-platform/index.js
@@ -4,6 +4,8 @@ import extractors from './extractors/index.js';
 
 import { selfAndAllFlowElements, getParents, getElement } from '../shared/util/ElementsUtil.js';
 
+export { getScope } from './util/ProcessVariablesUtil.js';
+
 /**
  * @typedef {Object} ProcessVariable
  * @property {string} name

--- a/src/camunda-platform/util/ProcessVariablesUtil.js
+++ b/src/camunda-platform/util/ProcessVariablesUtil.js
@@ -58,7 +58,7 @@ export function createProcessVariable(flowElement, name, defaultScope, targetSel
  *
  * @return {ModdleElement} scope for the variable
  */
-function getScope(element, globalScope, variableName, includeSelf = false) {
+export function getScope(element, globalScope, variableName, includeSelf = false) {
   var parents = getParents(element, includeSelf);
 
   // local variables are created through an input mapping

--- a/src/zeebe/extractors/extractResultVariables.js
+++ b/src/zeebe/extractors/extractResultVariables.js
@@ -1,5 +1,5 @@
 import { forEach, isArray } from 'min-dash';
-import { getCalledDecision, getOutputMappings, getScript } from '../util/ExtensionElementsUtil.js';
+import { getCalledDecision, getScript } from '../util/ExtensionElementsUtil.js';
 
 import { createProcessVariable, addVariableToList } from '../util/ProcessVariablesUtil.js';
 
@@ -57,10 +57,6 @@ export default function extractResultVariables(options) {
 
     var resultVariable = extensionElement.resultVariable;
 
-    if (hasOutMappings(element)) {
-      containerElement = element;
-    }
-
     if (resultVariable) {
       var newVariable = createProcessVariable(
         element,
@@ -74,10 +70,4 @@ export default function extractResultVariables(options) {
   });
 
   return processVariables;
-}
-
-function hasOutMappings(element) {
-  var outMappings = getOutputMappings(element);
-
-  return outMappings && outMappings.length;
 }

--- a/src/zeebe/index.js
+++ b/src/zeebe/index.js
@@ -4,6 +4,8 @@ import extractors from './extractors/index.js';
 
 import { selfAndAllFlowElements, getParents, getElement } from '../shared/util/ElementsUtil.js';
 
+export { getScope } from './util/ProcessVariablesUtil.js';
+
 /**
  * @typedef {Object} ProcessVariable
  * @property {string} name

--- a/src/zeebe/util/ProcessVariablesUtil.js
+++ b/src/zeebe/util/ProcessVariablesUtil.js
@@ -1,6 +1,6 @@
 import { find, findIndex } from 'min-dash';
 
-import { getInputMappings } from './ExtensionElementsUtil.js';
+import { getInputMappings, getOutputMappings } from './ExtensionElementsUtil.js';
 
 import { getParents } from '../../shared/util/ElementsUtil.js';
 
@@ -58,12 +58,17 @@ export function createProcessVariable(flowElement, name, defaultScope, targetSel
  * @return {ModdleElement} scope for the variable
  */
 export function getScope(element, globalScope, variableName, includeSelf = false) {
+
+  // (1) if an element defines an output mapping
+  // then the variable is local
+  if (includeSelf && hasOutputMappings(element)) {
+    return element;
+  }
+
+  // (2) otherwise, search parents upwards, to determine the closest
+  // scope that declares the variable (via a matching input mapping)
   var parents = getParents(element, includeSelf);
 
-  // local variables are created through an input mapping
-  //
-  // find the closes scope parent that defines the input mapping
-  // matching a given variable, that is the scope
   var scopedParent = find(parents, function(parent) {
     return (
       hasInputMapping(parent, variableName)
@@ -73,6 +78,27 @@ export function getScope(element, globalScope, variableName, includeSelf = false
   return scopedParent ? scopedParent : globalScope;
 }
 
+/**
+ * Does element define output mappings?
+ *
+ * @param {ModdleElement} element
+ *
+ * @return {boolean}
+ */
+function hasOutputMappings(element) {
+  var outputMappings = getOutputMappings(element);
+
+  return outputMappings && outputMappings.length > 0;
+}
+
+/**
+ * Does element define an input mapping for the given name?
+ *
+ * @param {ModdleElement} element
+ * @param {string} name
+ *
+ * @return {boolean}
+ */
 function hasInputMapping(element, name) {
   return find(getInputMappings(element), function(input) {
 

--- a/src/zeebe/util/ProcessVariablesUtil.js
+++ b/src/zeebe/util/ProcessVariablesUtil.js
@@ -46,15 +46,24 @@ export function createProcessVariable(flowElement, name, defaultScope, targetSel
 // helpers ////////////////////
 
 /**
- * Set parent container if it defines it's own scope for the variable, so
- * when it defines an input mapping for it. Otherwise returns the default global scope
+ * Determines the scope of a given variable, by examining the element
+ * and its parents. If no scope can be determined, return a specified
+ * global scope.
+ *
+ * @param {ModdleElement} element
+ * @param {ModdleElement} globalScope
+ * @param {string} variableName
+ * @param {boolean} [includeSelf=false]
+ *
+ * @return {ModdleElement} scope for the variable
  */
-function getScope(element, globalScope, variableName, includeSelf) {
+function getScope(element, globalScope, variableName, includeSelf = false) {
   var parents = getParents(element, includeSelf);
 
-  // local variables in sub-processes have to be explicitly created
-  // https://docs.camunda.io/docs/components/modeler/bpmn/embedded-subprocesses/#variable-mappings
-
+  // local variables are created through an input mapping
+  //
+  // find the closes scope parent that defines the input mapping
+  // matching a given variable, that is the scope
   var scopedParent = find(parents, function(parent) {
     return (
       hasInputMapping(parent, variableName)

--- a/src/zeebe/util/ProcessVariablesUtil.js
+++ b/src/zeebe/util/ProcessVariablesUtil.js
@@ -57,7 +57,7 @@ export function createProcessVariable(flowElement, name, defaultScope, targetSel
  *
  * @return {ModdleElement} scope for the variable
  */
-function getScope(element, globalScope, variableName, includeSelf = false) {
+export function getScope(element, globalScope, variableName, includeSelf = false) {
   var parents = getParents(element, includeSelf);
 
   // local variables are created through an input mapping

--- a/test/camunda-platform/spec/ProcessVariablesSpec.js
+++ b/test/camunda-platform/spec/ProcessVariablesSpec.js
@@ -14,7 +14,7 @@ import {
 } from '@bpmn-io/extract-process-variables';
 
 
-describe('process variables module', function() {
+describe('camunda-platform / process variables module', function() {
 
   describe('#getProcessVariables', function() {
 

--- a/test/camunda-platform/spec/extractors/extractEventDefinitionVariablesSpec.js
+++ b/test/camunda-platform/spec/extractors/extractEventDefinitionVariablesSpec.js
@@ -13,7 +13,7 @@ import extractVariables from '../../../../src/camunda-platform/extractors/extrac
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
 
 
-describe('extractors - event definition variables', function() {
+describe('camunda-platform / extractors - event definition variables', function() {
 
   it('should extract variables from error code variable', async function() {
 

--- a/test/camunda-platform/spec/extractors/extractFormFieldsSpec.js
+++ b/test/camunda-platform/spec/extractors/extractFormFieldsSpec.js
@@ -13,7 +13,7 @@ import extractVariables from '../../../../src/camunda-platform/extractors/extrac
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
 
 
-describe('extractors - form fields', function() {
+describe('camunda-platform / extractors - form fields', function() {
 
   it('should extract variables from form fields', async function() {
 

--- a/test/camunda-platform/spec/extractors/extractOutputMappingsSpec.js
+++ b/test/camunda-platform/spec/extractors/extractOutputMappingsSpec.js
@@ -13,7 +13,7 @@ import extractVariables from '../../../../src/camunda-platform/extractors/extrac
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
 
 
-describe('extractors - output mappings', function() {
+describe('camunda-platform / extractors - output mappings', function() {
 
   it('should extract variables from out mappings', async function() {
 

--- a/test/camunda-platform/spec/extractors/extractOutputParametersSpec.js
+++ b/test/camunda-platform/spec/extractors/extractOutputParametersSpec.js
@@ -13,7 +13,7 @@ import extractVariables from '../../../../src/camunda-platform/extractors/extrac
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
 
 
-describe('extractors - output parameters', function() {
+describe('camunda-platform / extractors - output parameters', function() {
 
   it('should extract variables from output parameters', async function() {
 

--- a/test/camunda-platform/spec/extractors/extractResultVariables.js
+++ b/test/camunda-platform/spec/extractors/extractResultVariables.js
@@ -13,7 +13,7 @@ import extractVariables from '../../../../src/camunda-platform/extractors/extrac
 import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil.js';
 
 
-describe('extractors - result variables', function() {
+describe('camunda-platform / extractors - result variables', function() {
 
   it('should extract variables from result variables', async function() {
 

--- a/test/distro/extract-process-variables.cjs
+++ b/test/distro/extract-process-variables.cjs
@@ -13,7 +13,7 @@ describe('extract-process-variables - distribution', function() {
   });
 
 
-  it('should expose zeebe CJS bundle', function() {
+  it('should expose CJS bundle / zeebe', function() {
     const { getProcessVariables, getScope } = require('@bpmn-io/extract-process-variables/zeebe');
 
     expect(getProcessVariables).to.exist;

--- a/test/distro/extract-process-variables.cjs
+++ b/test/distro/extract-process-variables.cjs
@@ -6,16 +6,18 @@ const {
 describe('extract-process-variables - distribution', function() {
 
   it('should expose CJS bundle', function() {
-    const extractProcessVariables = require('@bpmn-io/extract-process-variables');
+    const { getProcessVariables, getScope } = require('@bpmn-io/extract-process-variables');
 
-    expect(extractProcessVariables.getProcessVariables).to.exist;
+    expect(getProcessVariables).to.exist;
+    expect(getScope).to.exist;
   });
 
 
   it('should expose zeebe CJS bundle', function() {
-    const extractProcessVariables = require('@bpmn-io/extract-process-variables/zeebe');
+    const { getProcessVariables, getScope } = require('@bpmn-io/extract-process-variables/zeebe');
 
-    expect(extractProcessVariables.getProcessVariables).to.exist;
+    expect(getProcessVariables).to.exist;
+    expect(getScope).to.exist;
   });
 
 });

--- a/test/distro/extract-process-variables.js
+++ b/test/distro/extract-process-variables.js
@@ -6,20 +6,22 @@ describe('extract-process-variables - distribution', function() {
   it('should expose ESM bundle', async function() {
 
     // when
-    const imported = await import('@bpmn-io/extract-process-variables');
+    const { getProcessVariables, getScope } = await import('@bpmn-io/extract-process-variables');
 
     // then
-    expect(imported).to.exist;
+    expect(getProcessVariables).to.exist;
+    expect(getScope).to.exist;
   });
 
 
   it('should expose zeebe ESM bundle', async function() {
 
     // when
-    const imported = await import('@bpmn-io/extract-process-variables/zeebe');
+    const { getProcessVariables, getScope } = await import('@bpmn-io/extract-process-variables/zeebe');
 
     // then
-    expect(imported).to.exist;
+    expect(getProcessVariables).to.exist;
+    expect(getScope).to.exist;
   });
 
 });

--- a/test/distro/extract-process-variables.js
+++ b/test/distro/extract-process-variables.js
@@ -14,7 +14,7 @@ describe('extract-process-variables - distribution', function() {
   });
 
 
-  it('should expose zeebe ESM bundle', async function() {
+  it('should expose ESM bundle / zeebe', async function() {
 
     // when
     const { getProcessVariables, getScope } = await import('@bpmn-io/extract-process-variables/zeebe');

--- a/test/zeebe/TestHelper.js
+++ b/test/zeebe/TestHelper.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai';
+
 import { map } from 'min-dash';
 
 import { BpmnModdle } from 'bpmn-moddle';
@@ -9,6 +11,15 @@ import fs from 'node:fs';
 
 export function getRootElement(model) {
   return model.rootElement.get('rootElements')[0];
+}
+
+export function getElement(model, id) {
+
+  const element = model.elementsById[id];
+
+  expect(element, `element[id=${id}]`).to.exist;
+
+  return element;
 }
 
 export async function parseXML(xml) {

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -15,7 +15,7 @@ import {
 } from '@bpmn-io/extract-process-variables/zeebe';
 
 
-describe('zeebe/process variables module', function() {
+describe('zeebe / process variables module', function() {
 
   describe('#getProcessVariables', function() {
 

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -190,48 +190,54 @@ describe('zeebe / process variables module', function() {
     });
 
 
-    it('should extract variables / additional extractors', async function() {
+    describe('additional extractors', function() {
 
-      // given
-      const model = await readModel('test/zeebe/fixtures/simple.bpmn');
+      it('should add global variable', async function() {
 
-      const rootElement = getRootElement(model);
+        // given
+        const model = await readModel('test/zeebe/fixtures/simple.bpmn');
 
-      // when
-      const variables = await getProcessVariables(rootElement, [
-        additionalExtractor(rootElement)
-      ]);
+        const rootElement = getRootElement(model);
 
-      // then
-      expect(convertToTestable(variables)).to.eql([
-        { name: 'variable3', origin: [ 'Task_1' ], scope: 'Task_1' },
-        { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' },
-      ]);
+        // when
+        const variables = await getProcessVariables(rootElement, [
+          additionalExtractor(rootElement)
+        ]);
+
+        // then
+        expect(convertToTestable(variables)).to.eql([
+          { name: 'variable3', origin: [ 'Task_1' ], scope: 'Task_1' },
+          { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' },
+        ]);
+      });
 
     });
 
 
-    it('should extract variables / additional extractors / async', async function() {
+    describe('additional extractors (async)', function() {
 
-      // given
-      const model = await readModel('test/zeebe/fixtures/simple.bpmn');
+      it('should add global variable', async function() {
 
-      const rootElement = getRootElement(model);
+        // given
+        const model = await readModel('test/zeebe/fixtures/simple.bpmn');
 
-      // when
-      const variables = await getProcessVariables(rootElement, [
-        asyncAdditionalExtractor(rootElement)
-      ]);
+        const rootElement = getRootElement(model);
 
-      // then
-      expect(convertToTestable(variables)).to.eql([
-        { name: 'variable3', origin: [ 'Task_1' ], scope: 'Task_1' },
-        { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' },
-      ]);
+        // when
+        const variables = await getProcessVariables(rootElement, [
+          asyncAdditionalExtractor(rootElement)
+        ]);
+
+        // then
+        expect(convertToTestable(variables)).to.eql([
+          { name: 'variable3', origin: [ 'Task_1' ], scope: 'Task_1' },
+          { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' },
+        ]);
+      });
 
     });
 
@@ -485,46 +491,52 @@ describe('zeebe / process variables module', function() {
     });
 
 
-    it('should extract variables / additional extractors', async function() {
+    describe('additional extractors', function() {
 
-      // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      it('should add global variable', async function() {
 
-      const rootElement = getRootElement(model);
+        // given
+        const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      // when
-      const variables = await getVariablesForScope('Process_1', rootElement, [
-        additionalExtractor(rootElement)
-      ]);
+        const rootElement = getRootElement(model);
 
-      // then
-      expect(convertToTestable(variables)).to.eql([
-        { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' }
-      ]);
+        // when
+        const variables = await getVariablesForScope('Process_1', rootElement, [
+          additionalExtractor(rootElement)
+        ]);
+
+        // then
+        expect(convertToTestable(variables)).to.eql([
+          { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' }
+        ]);
+      });
 
     });
 
 
-    it('should extract variables / additional extractors (async)', async function() {
+    describe('additional extractors (async)', function() {
 
-      // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      it('should add global variable', async function() {
 
-      const rootElement = getRootElement(model);
+        // given
+        const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      // when
-      const variables = await getVariablesForScope('Process_1', rootElement, [
-        asyncAdditionalExtractor(rootElement)
-      ]);
+        const rootElement = getRootElement(model);
 
-      // then
-      expect(convertToTestable(variables)).to.eql([
-        { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' }
-      ]);
+        // when
+        const variables = await getVariablesForScope('Process_1', rootElement, [
+          asyncAdditionalExtractor(rootElement)
+        ]);
+
+        // then
+        expect(convertToTestable(variables)).to.eql([
+          { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' }
+        ]);
+      });
 
     });
 
@@ -576,46 +588,53 @@ describe('zeebe / process variables module', function() {
     });
 
 
-    it('should extract variables / additional extractors', async function() {
+    describe('additional extractors', function() {
 
-      // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      it('should add global variable', async function() {
 
-      const rootElement = getRootElement(model);
+        // given
+        const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      // when
-      const variables = await getVariablesForElement(rootElement, [
-        additionalExtractor(rootElement)
-      ]);
+        const rootElement = getRootElement(model);
 
-      // then
-      expect(convertToTestable(variables)).to.eql([
-        { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' },
-      ]);
+        // when
+        const variables = await getVariablesForElement(rootElement, [
+          additionalExtractor(rootElement)
+        ]);
+
+        // then
+        expect(convertToTestable(variables)).to.eql([
+          { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' },
+        ]);
+      });
 
     });
 
 
-    it('should extract variables / additional extractors (async)', async function() {
+    describe('additional extractors (async)', function() {
 
-      // given
-      const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
+      it('should add global variable', async function() {
 
-      const rootElement = getRootElement(model);
+        // given
+        const model = await readModel('test/zeebe/fixtures/sub-process.own-scope.bpmn');
 
-      // when
-      const variables = await getVariablesForElement(rootElement, [
-        asyncAdditionalExtractor(rootElement)
-      ]);
+        const rootElement = getRootElement(model);
 
-      // then
-      expect(convertToTestable(variables)).to.eql([
-        { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
-        { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' },
-      ]);
+        // when
+        const variables = await getVariablesForElement(rootElement, [
+          asyncAdditionalExtractor(rootElement)
+        ]);
+
+        // then
+        expect(convertToTestable(variables)).to.eql([
+          { name: 'variable1', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'variable2', origin: [ 'Task_1' ], scope: 'Process_1' },
+          { name: 'additionalVariable', origin: [ 'Process_1' ], scope: 'Process_1' },
+        ]);
+
+      });
 
     });
 

--- a/test/zeebe/spec/extractors/extractInputElementSpec.js
+++ b/test/zeebe/spec/extractors/extractInputElementSpec.js
@@ -6,7 +6,7 @@ import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil
 import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
-describe('zeebe/extractors - input element', function() {
+describe('zeebe / extractors - input element', function() {
 
   it('should extract variables from input elements', async function() {
 

--- a/test/zeebe/spec/extractors/extractInputMappingsSpec.js
+++ b/test/zeebe/spec/extractors/extractInputMappingsSpec.js
@@ -6,7 +6,7 @@ import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil
 import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
-describe('zeebe/extractors - input mappings', function() {
+describe('zeebe / extractors - input mappings', function() {
 
   it('should extract variables for sub-process', async function() {
 

--- a/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
@@ -6,7 +6,7 @@ import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil
 import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
-describe('zeebe/extractors - output collections', function() {
+describe('zeebe / extractors - output collections', function() {
 
   describe('multi-instance sub process', function() {
 

--- a/test/zeebe/spec/extractors/extractOutputMappingsSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputMappingsSpec.js
@@ -6,7 +6,7 @@ import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil
 import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
-describe('zeebe/extractors - output mappings', function() {
+describe('zeebe / extractors - output mappings', function() {
 
   it('should extract variables / simple', async function() {
 

--- a/test/zeebe/spec/extractors/extractResultVariablesSpec.js
+++ b/test/zeebe/spec/extractors/extractResultVariablesSpec.js
@@ -6,7 +6,7 @@ import { selfAndAllFlowElements } from '../../../../src/shared/util/ElementsUtil
 import { convertToTestable, getRootElement, readModel } from '../../TestHelper.js';
 
 
-describe('zeebe/extractors - result variables', function() {
+describe('zeebe / extractors - result variables', function() {
 
   it('should extract variables from called decision', async function() {
 


### PR DESCRIPTION
### Proposed Changes

> [!NOTE] 
> Does not ship any breaking changes in `@bpmn-io/variable-resolver` (validated via local linking).


* Expose `getScope` for use by downstream integrators (https://github.com/bpmn-io/variable-resolver)
* Ensure Camunda 8 `outputCollection` always leaks - existing, observable engine behavior
* Test improvements, additions


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->

---

Depends on https://github.com/bpmn-io/extract-process-variables/pull/35