### PR TITLE
Correct scope of `outputCollection` defined variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@bpmn-io/extract-process-variables](https://github.com/b
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: correct `outputCollection` scoping ([#36](https://github.com/bpmn-io/extract-process-variables/pull/36))
+
 ## 2.2.0
 
 * `FEAT`: recognize output mapping variables with paths ([#35](https://github.com/bpmn-io/extract-process-variables/pull/35))

--- a/src/zeebe/extractors/extractOutputCollections.js
+++ b/src/zeebe/extractors/extractOutputCollections.js
@@ -36,16 +36,20 @@ export default function extractOutputCollections(options) {
     elements = [ elements ];
   }
 
+  // <outputCollection> defines a local variable that always propagates
+  // to the parent scope upon completion
   forEach(elements, function(element) {
 
     var multiInstanceOutputCollection = getMultiInstanceOutputCollection(element);
 
     if (multiInstanceOutputCollection) {
+
+      // <outputCollection> declared variable is not available
+      // in local scope, but only in the MI parent.
       const newVariable = createProcessVariable(
         element,
         multiInstanceOutputCollection,
-        containerElement,
-        true
+        containerElement
       );
 
       addVariableToList(processVariables, newVariable);
@@ -55,14 +59,25 @@ export default function extractOutputCollections(options) {
 
     if (adHocOutputCollection) {
 
-      const newVariable = createProcessVariable(
+      // <outputCollection> declared variable is available in ad-hoc local
+      // scope as a local variable
+      const newLocalVariable = createProcessVariable(
         element,
         adHocOutputCollection,
-        containerElement,
-        true
+        element
       );
 
-      addVariableToList(processVariables, newVariable);
+      addVariableToList(processVariables, newLocalVariable);
+
+      // <outputCollection> declared variable also "force propagates" to the
+      // parent scope
+      const newParentVariable = createProcessVariable(
+        element,
+        adHocOutputCollection,
+        containerElement
+      );
+
+      addVariableToList(processVariables, newParentVariable);
     }
   });
 

--- a/test/camunda-platform/spec/ProcessVariablesSpec.js
+++ b/test/camunda-platform/spec/ProcessVariablesSpec.js
@@ -178,7 +178,7 @@ describe('camunda-platform / process variables module', function() {
       // when
       const variables = await getProcessVariables(rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
       expect(convertToTestable(sortedVariables)).to.eql([
@@ -287,7 +287,7 @@ describe('camunda-platform / process variables module', function() {
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -312,7 +312,7 @@ describe('camunda-platform / process variables module', function() {
       // when
       const variables = await getVariablesForScope('SubProcess_2', rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -408,9 +408,9 @@ function read(path, encoding = 'utf8') {
   return fs.readFileSync(path, encoding);
 }
 
-function sortVariablesByName(variables) {
+function sortVariables(variables) {
   return sortBy(variables, function(variable) {
-    return variable.name;
+    return `${variable.name} ~ ${variable.scope ?? ''}`;
   });
 }
 

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -391,7 +391,7 @@ describe('zeebe / process variables module', function() {
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -414,7 +414,7 @@ describe('zeebe / process variables module', function() {
       // when
       const variables = await getVariablesForScope('AdHocSubProcess_1', rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -437,7 +437,7 @@ describe('zeebe / process variables module', function() {
       // when
       const variables = await getVariablesForScope('AdHocSubProcess_1', rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -478,7 +478,7 @@ describe('zeebe / process variables module', function() {
       // when
       const variables = await getVariablesForScope('AdHocSubProcess_1', rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -511,7 +511,7 @@ describe('zeebe / process variables module', function() {
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -533,7 +533,7 @@ describe('zeebe / process variables module', function() {
       // when
       const variables = await getVariablesForScope('SubProcess_1', rootElement);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -630,7 +630,7 @@ describe('zeebe / process variables module', function() {
       // when
       const variables = await getVariablesForElement(subProcess);
 
-      const sortedVariables = sortVariablesByName(variables);
+      const sortedVariables = sortVariables(variables);
 
       // then
 
@@ -766,9 +766,9 @@ describe('zeebe / process variables module', function() {
 
 // helpers //////////
 
-function sortVariablesByName(variables) {
+function sortVariables(variables) {
   return sortBy(variables, function(variable) {
-    return variable.name;
+    return `${variable.name} ~ ${variable.scope ?? ''}`;
   });
 }
 

--- a/test/zeebe/spec/ProcessVariablesSpec.js
+++ b/test/zeebe/spec/ProcessVariablesSpec.js
@@ -421,6 +421,7 @@ describe('zeebe / process variables module', function() {
       // own + all variables from parent scope
       expect(convertToTestable(sortedVariables)).to.eql([
         { name: 'variable', origin: [ 'Task_1' ], scope: 'Process_1' },
+        { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' },
         { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'Process_1' }
       ]);
     });
@@ -459,7 +460,10 @@ describe('zeebe / process variables module', function() {
           ],
           scope: 'AdHocSubProcess_1'
         },
-        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' },
+
+        // always leaks to parent, is un-local-scopable
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'Process_1' }
       ]);
     });
 
@@ -489,7 +493,10 @@ describe('zeebe / process variables module', function() {
           scope: 'AdHocSubProcess_1'
         },
         { name: 'toolResult.email', origin: [ 'ScriptTask_2' ], scope: 'AdHocSubProcess_1' },
-        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' },
+
+        // always leaks to parent, is un-local-scopable
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'Process_1' }
       ]);
     });
 
@@ -533,7 +540,10 @@ describe('zeebe / process variables module', function() {
       // own + all variables from parent scope
       expect(convertToTestable(sortedVariables)).to.eql([
         { name: 'inputElement', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' },
-        { name: 'outputCollection', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' }
+        { name: 'outputCollection', origin: [ 'SubProcess_1' ], scope: 'SubProcess_1' },
+
+        // always leaks to parent, is un-local-scopable
+        { name: 'outputCollection', origin: [ 'SubProcess_1' ], scope: 'Process_1' }
       ]);
     });
 

--- a/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
@@ -33,6 +33,29 @@ describe('zeebe / extractors - output collections', function() {
     });
 
 
+    it('should extract variables / un-local-scopable', async function() {
+
+      // given
+      const model = await readModel('test/zeebe/fixtures/sub-process.multi-instance-own-scope.bpmn');
+
+      const rootElement = getRootElement(model);
+
+      const elements = selfAndAllFlowElements([ rootElement ], false);
+
+      // when
+      const variables = extractVariables({
+        elements,
+        containerElement: rootElement,
+        processVariables: []
+      });
+
+      // then
+      expect(convertToTestable(variables)).to.eql([
+        { name: 'outputCollection', origin: [ 'SubProcess_1' ], scope: 'Process_1' }
+      ]);
+    });
+
+
     it('should not extract variables / empty loopCharacteristics', async function() {
 
       // given
@@ -76,12 +99,13 @@ describe('zeebe / extractors - output collections', function() {
 
       // then
       expect(convertToTestable(variables)).to.eql([
+        { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' },
         { name: 'variables', origin: [ 'AdHocSubProcess_1' ], scope: 'Process_1' }
       ]);
     });
 
 
-    it('should extract variables / scoped', async function() {
+    it('should extract variables / un-local-scopable', async function() {
 
       // given
       const model = await readModel('test/zeebe/fixtures/ad-hoc-sub-process.own-scope.bpmn');
@@ -99,7 +123,8 @@ describe('zeebe / extractors - output collections', function() {
 
       // then
       expect(convertToTestable(variables)).to.eql([
-        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' }
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' },
+        { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'Process_1' }
       ]);
     });
 

--- a/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
+++ b/test/zeebe/spec/extractors/extractOutputCollectionSpec.js
@@ -51,6 +51,8 @@ describe('zeebe / extractors - output collections', function() {
 
       // then
       expect(convertToTestable(variables)).to.eql([
+
+        // always leaks to parent, is un-local-scopable
         { name: 'outputCollection', origin: [ 'SubProcess_1' ], scope: 'Process_1' }
       ]);
     });
@@ -124,6 +126,8 @@ describe('zeebe / extractors - output collections', function() {
       // then
       expect(convertToTestable(variables)).to.eql([
         { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'AdHocSubProcess_1' },
+
+        // always leaks to parent, is un-local-scopable
         { name: 'toolResults', origin: [ 'AdHocSubProcess_1' ], scope: 'Process_1' }
       ]);
     });


### PR DESCRIPTION
### Proposed Changes

Output collection always propagates to the parent. For ad-hoc sub-processes it is available as a local variable, because it can be used by the connected job worker.

For multi-instance activities we don't allow the user to access the variable - it is not available locally / we don't represent the MI body scope.

Related to https://github.com/camunda/camunda/issues/46530

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
